### PR TITLE
illustrated computer vision through multiple models

### DIFF
--- a/ch_17_omputer_vision_.ipynb
+++ b/ch_17_omputer_vision_.ipynb
@@ -1,0 +1,2013 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In the computer vision of deep learning , we give the computer capacity to see  and observe the things like deciding between cat, dog and chicjer , drawing box around cat and splitting image into road ,cat , person and sky."
+      ],
+      "metadata": {
+        "id": "JQV4k3KEZg4l"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\n",
+        "In this notebook , we will learn about the diffrent pytorch vision libaries from torchvison , dataloader , etc . loading the simple dataset , use dataloader to serves dataset into batches in order to train model efffectivelu"
+      ],
+      "metadata": {
+        "id": "tX4Zf3nMZzdL"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Similalry , we will first build and train simple baseline layers , with whom other model accuracy can be contrasted .   \n",
+        "We will build better models with non-linearilty and cnn , compare them with the baseline model and save the best one ."
+      ],
+      "metadata": {
+        "id": "HtRHkASgaZPO"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Pytorch has got bundle of tools and libaries to achie this :\n",
+        "*   torchvision : bundle of image datasets , reayd made architecture , and common image transforms\n",
+        "*   torchvision.datasets : ready made dataset like fashionminst, cifrar etc along with the class to build our own datasets .\n",
+        "* torchvision.models: predefined architecture which we can reuse and fine tune\n",
+        "* torvhvision.transforms : function to convert images to tensors, resize , normalize or agument them\n",
+        "* torch.utils.data.Dataset : base class saying this is the dataset\n",
+        "* torch.utils.data.DataLoader : used to provide dataset on minibatch for the effective training of the model\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "n8Dhc5ySayHS"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "lets import all of these things"
+      ],
+      "metadata": {
+        "id": "R-iAE4C6cL_k"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Import PyTorch\n",
+        "import torch\n",
+        "from torch import nn\n",
+        "\n",
+        "# Import torchvision\n",
+        "import torchvision\n",
+        "from torchvision import datasets\n",
+        "from torchvision.transforms import ToTensor\n",
+        "\n",
+        "# Import matplotlib for visualization\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "# Check versions\n",
+        "# Note: your PyTorch version shouldn't be lower than 1.10.0 and torchvision version shouldn't be lower than 0.11\n",
+        "print(f\"PyTorch version: {torch.__version__}\\ntorchvision version: {torchvision.__version__}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WV6V8nmtcY00",
+        "outputId": "c97fa3b8-f93d-477b-d908-3e1ede3cfbe3"
+      },
+      "execution_count": 29,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "PyTorch version: 2.9.0+cu126\n",
+            "torchvision version: 0.24.0+cu126\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Here , we will use the already inbuilt dataset  called FashionMnist . This dataset contain the 10 possible classes of clothing item ranging from tshirt, trouser, pullover , dresscoat, sandal , etc .\n",
+        "\n",
+        "Since , this is already inbuilt and avaible with the pytorch , we dont need to do anything extra , we will directly setup training and test data for this"
+      ],
+      "metadata": {
+        "id": "Knk7nVHseGEc"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Setup training data\n",
+        "train_data = datasets.FashionMNIST(\n",
+        "    root=\"data\", # where to download data to?\n",
+        "    train=True, # get training data\n",
+        "    download=True, # download data if it doesn't exist on disk\n",
+        "    transform=ToTensor(), # images come as PIL format, we want to turn into Torch tensors\n",
+        "    target_transform=None # you can transform labels as well\n",
+        ")\n",
+        "\n",
+        "# Setup testing data\n",
+        "test_data = datasets.FashionMNIST(\n",
+        "    root=\"data\",\n",
+        "    train=False, # get test data\n",
+        "    download=True,\n",
+        "    transform=ToTensor()\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "0swWeTZufEnc"
+      },
+      "execution_count": 30,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "since this are transfprmed to transer let get image and label of first dtaa of train_data"
+      ],
+      "metadata": {
+        "id": "NZBa9_oLfhEo"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# See first training sample\n",
+        "image, label = train_data[0]\n",
+        "image, label\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "qRZ07CP7foqF",
+        "outputId": "ef865520-8db4-46dd-bc29-65b0e5aee060"
+      },
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(tensor([[[0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0039, 0.0000, 0.0000, 0.0510,\n",
+              "           0.2863, 0.0000, 0.0000, 0.0039, 0.0157, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0039, 0.0039, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0118, 0.0000, 0.1412, 0.5333,\n",
+              "           0.4980, 0.2431, 0.2118, 0.0000, 0.0000, 0.0000, 0.0039, 0.0118,\n",
+              "           0.0157, 0.0000, 0.0000, 0.0118],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0235, 0.0000, 0.4000, 0.8000,\n",
+              "           0.6902, 0.5255, 0.5647, 0.4824, 0.0902, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0471, 0.0392, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.6078, 0.9255,\n",
+              "           0.8118, 0.6980, 0.4196, 0.6118, 0.6314, 0.4275, 0.2510, 0.0902,\n",
+              "           0.3020, 0.5098, 0.2824, 0.0588],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0039, 0.0000, 0.2706, 0.8118, 0.8745,\n",
+              "           0.8549, 0.8471, 0.8471, 0.6392, 0.4980, 0.4745, 0.4784, 0.5725,\n",
+              "           0.5529, 0.3451, 0.6745, 0.2588],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0039, 0.0039, 0.0039, 0.0000, 0.7843, 0.9098, 0.9098,\n",
+              "           0.9137, 0.8980, 0.8745, 0.8745, 0.8431, 0.8353, 0.6431, 0.4980,\n",
+              "           0.4824, 0.7686, 0.8980, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.7176, 0.8824, 0.8471,\n",
+              "           0.8745, 0.8941, 0.9216, 0.8902, 0.8784, 0.8706, 0.8784, 0.8667,\n",
+              "           0.8745, 0.9608, 0.6784, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.7569, 0.8941, 0.8549,\n",
+              "           0.8353, 0.7765, 0.7059, 0.8314, 0.8235, 0.8275, 0.8353, 0.8745,\n",
+              "           0.8627, 0.9529, 0.7922, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0039, 0.0118, 0.0000, 0.0471, 0.8588, 0.8627, 0.8314,\n",
+              "           0.8549, 0.7529, 0.6627, 0.8902, 0.8157, 0.8549, 0.8784, 0.8314,\n",
+              "           0.8863, 0.7725, 0.8196, 0.2039],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0235, 0.0000, 0.3882, 0.9569, 0.8706, 0.8627,\n",
+              "           0.8549, 0.7961, 0.7765, 0.8667, 0.8431, 0.8353, 0.8706, 0.8627,\n",
+              "           0.9608, 0.4667, 0.6549, 0.2196],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0157, 0.0000, 0.0000, 0.2157, 0.9255, 0.8941, 0.9020,\n",
+              "           0.8941, 0.9412, 0.9098, 0.8353, 0.8549, 0.8745, 0.9176, 0.8510,\n",
+              "           0.8510, 0.8196, 0.3608, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0039, 0.0157, 0.0235, 0.0275, 0.0078, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.9294, 0.8863, 0.8510, 0.8745,\n",
+              "           0.8706, 0.8588, 0.8706, 0.8667, 0.8471, 0.8745, 0.8980, 0.8431,\n",
+              "           0.8549, 1.0000, 0.3020, 0.0000],\n",
+              "          [0.0000, 0.0118, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.2431, 0.5686, 0.8000, 0.8941, 0.8118, 0.8353, 0.8667,\n",
+              "           0.8549, 0.8157, 0.8275, 0.8549, 0.8784, 0.8745, 0.8588, 0.8431,\n",
+              "           0.8784, 0.9569, 0.6235, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0706, 0.1725, 0.3216, 0.4196,\n",
+              "           0.7412, 0.8941, 0.8627, 0.8706, 0.8510, 0.8863, 0.7843, 0.8039,\n",
+              "           0.8275, 0.9020, 0.8784, 0.9176, 0.6902, 0.7373, 0.9804, 0.9725,\n",
+              "           0.9137, 0.9333, 0.8431, 0.0000],\n",
+              "          [0.0000, 0.2235, 0.7333, 0.8157, 0.8784, 0.8667, 0.8784, 0.8157,\n",
+              "           0.8000, 0.8392, 0.8157, 0.8196, 0.7843, 0.6235, 0.9608, 0.7569,\n",
+              "           0.8078, 0.8745, 1.0000, 1.0000, 0.8667, 0.9176, 0.8667, 0.8275,\n",
+              "           0.8627, 0.9098, 0.9647, 0.0000],\n",
+              "          [0.0118, 0.7922, 0.8941, 0.8784, 0.8667, 0.8275, 0.8275, 0.8392,\n",
+              "           0.8039, 0.8039, 0.8039, 0.8627, 0.9412, 0.3137, 0.5882, 1.0000,\n",
+              "           0.8980, 0.8667, 0.7373, 0.6039, 0.7490, 0.8235, 0.8000, 0.8196,\n",
+              "           0.8706, 0.8941, 0.8824, 0.0000],\n",
+              "          [0.3843, 0.9137, 0.7765, 0.8235, 0.8706, 0.8980, 0.8980, 0.9176,\n",
+              "           0.9765, 0.8627, 0.7608, 0.8431, 0.8510, 0.9451, 0.2549, 0.2863,\n",
+              "           0.4157, 0.4588, 0.6588, 0.8588, 0.8667, 0.8431, 0.8510, 0.8745,\n",
+              "           0.8745, 0.8784, 0.8980, 0.1137],\n",
+              "          [0.2941, 0.8000, 0.8314, 0.8000, 0.7569, 0.8039, 0.8275, 0.8824,\n",
+              "           0.8471, 0.7255, 0.7725, 0.8078, 0.7765, 0.8353, 0.9412, 0.7647,\n",
+              "           0.8902, 0.9608, 0.9373, 0.8745, 0.8549, 0.8314, 0.8196, 0.8706,\n",
+              "           0.8627, 0.8667, 0.9020, 0.2627],\n",
+              "          [0.1882, 0.7961, 0.7176, 0.7608, 0.8353, 0.7725, 0.7255, 0.7451,\n",
+              "           0.7608, 0.7529, 0.7922, 0.8392, 0.8588, 0.8667, 0.8627, 0.9255,\n",
+              "           0.8824, 0.8471, 0.7804, 0.8078, 0.7294, 0.7098, 0.6941, 0.6745,\n",
+              "           0.7098, 0.8039, 0.8078, 0.4510],\n",
+              "          [0.0000, 0.4784, 0.8588, 0.7569, 0.7020, 0.6706, 0.7176, 0.7686,\n",
+              "           0.8000, 0.8235, 0.8353, 0.8118, 0.8275, 0.8235, 0.7843, 0.7686,\n",
+              "           0.7608, 0.7490, 0.7647, 0.7490, 0.7765, 0.7529, 0.6902, 0.6118,\n",
+              "           0.6549, 0.6941, 0.8235, 0.3608],\n",
+              "          [0.0000, 0.0000, 0.2902, 0.7412, 0.8314, 0.7490, 0.6863, 0.6745,\n",
+              "           0.6863, 0.7098, 0.7255, 0.7373, 0.7412, 0.7373, 0.7569, 0.7765,\n",
+              "           0.8000, 0.8196, 0.8235, 0.8235, 0.8275, 0.7373, 0.7373, 0.7608,\n",
+              "           0.7529, 0.8471, 0.6667, 0.0000],\n",
+              "          [0.0078, 0.0000, 0.0000, 0.0000, 0.2588, 0.7843, 0.8706, 0.9294,\n",
+              "           0.9373, 0.9490, 0.9647, 0.9529, 0.9569, 0.8667, 0.8627, 0.7569,\n",
+              "           0.7490, 0.7020, 0.7137, 0.7137, 0.7098, 0.6902, 0.6510, 0.6588,\n",
+              "           0.3882, 0.2275, 0.0000, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.1569,\n",
+              "           0.2392, 0.1725, 0.2824, 0.1608, 0.1373, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000],\n",
+              "          [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,\n",
+              "           0.0000, 0.0000, 0.0000, 0.0000]]]),\n",
+              " 9)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 31
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "let see the shape of image to get deep die into the content\n"
+      ],
+      "metadata": {
+        "id": "jjU-nWJBfuEv"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# See first training sample shape\n",
+        "image.shape\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "UpSJ1WL7g1Ja",
+        "outputId": "d23a84fc-f099-405a-c036-b3d371c7aac0"
+      },
+      "execution_count": 32,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "torch.Size([1, 28, 28])"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 32
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "this torch.Size([1, 28, 28]) tells something in the pattern  that every photo in pur dataset is 1 layer of gray pixels, 28 dots tall, 28 dots wide.”​\n",
+        "\n",
+        "Understanding the 3 numbers is in the form of CHW\n",
+        "* The first number (C) is how many “color layers” the picture has. Since it’s black‑and‑white, there’s only one layer: brightness.​\n",
+        "\n",
+        "* The second number (H) is how tall the picture is, measured in pixels from top to bottom.\n",
+        "\n",
+        "* The third number (W) is how wide the picture is, measured from left to right."
+      ],
+      "metadata": {
+        "id": "xmlbi6eqg7ea"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Extending the above point , If value of C ois 3 then it is olored photo of RGB .\n",
+        "\n",
+        "SImilrly adding N = 32 in front of CHW becomes NCHW which means N ( 32 Here ) is stacked tpgether here ."
+      ],
+      "metadata": {
+        "id": "kLO_FwPchbFK"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "since we are directly importing the training and testing data from inbuilt one , we dont know how many sample are there in the testing and trainign dataset. Lets check of that too :"
+      ],
+      "metadata": {
+        "id": "r5Pb4KlMiAe0"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# How many samples are there?\n",
+        "len(train_data.data), len(train_data.targets), len(test_data.data), len(test_data.targets)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "sO0ixT95iPkc",
+        "outputId": "322a0dc4-2c7a-45e5-928d-76165e89725a"
+      },
+      "execution_count": 33,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(60000, 60000, 10000, 10000)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 33
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "It means 60K in the traing dataset and 10K in the testing dataset .\n",
+        "Laos , lets observe  what what clohing items our datset contain ."
+      ],
+      "metadata": {
+        "id": "TKsIPayuiU0G"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# See classes\n",
+        "class_names = train_data.classes\n",
+        "class_names"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "B2fcf3jNii0h",
+        "outputId": "6a4c41cc-d0d6-41c1-e596-8a44ec1e9c57"
+      },
+      "execution_count": 34,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['T-shirt/top',\n",
+              " 'Trouser',\n",
+              " 'Pullover',\n",
+              " 'Dress',\n",
+              " 'Coat',\n",
+              " 'Sandal',\n",
+              " 'Shirt',\n",
+              " 'Sneaker',\n",
+              " 'Bag',\n",
+              " 'Ankle boot']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 34
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "hmm, thet are tshirt , trouser, pullover, dress ,coat, sandal ,shirt, sneaker, bag and ankle boat ."
+      ],
+      "metadata": {
+        "id": "hTOE15Nnim2m"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "more sort of alidation , lets se the first images"
+      ],
+      "metadata": {
+        "id": "Y3eddfcJivXd"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "image, label = train_data[0]\n",
+        "print(\"Image shape:\", image.shape)\n",
+        "plt.imshow(image.squeeze())\n",
+        "plt.title(label)\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 487
+        },
+        "id": "HYNWHNevjSK5",
+        "outputId": "533dd95d-dccc-4f6f-a15c-8de55a972f6b"
+      },
+      "execution_count": 35,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Image shape: torch.Size([1, 28, 28])\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Text(0.5, 1.0, '9')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 35
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAGzCAYAAABpdMNsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJIZJREFUeJzt3Xt0lPW97/HP5DYEmEwIITcJGFBABWJLIaZYREmBtMcDyu7R1rMKPS4tGFxF2q0Lt4pau9Pi2tZTi3rO2i3UtcTbqsiWbTlVaIK0CcrtUGqbQhoFJQkXzUzIdZL5nT84RiPX38MkvyS8X2vNWmTm+fD8eHiST57MzDc+Y4wRAAC9LM71AgAAFycKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUE9JKdO3dq7ty5SklJUSAQ0OzZs7Vnzx7XywKc8TELDuh5u3bt0vTp05Wbm6vvf//7ikajevrpp/Xxxx/rnXfe0fjx410vEeh1FBDQC775zW+qoqJC+/fv1/DhwyVJtbW1GjdunGbPnq3f/va3jlcI9D5+BAf0grfffltFRUVd5SNJ2dnZuu6667Rx40adOHHC4eoANyggoBe0tbUpOTn5lPsHDx6s9vZ27du3z8GqALcoIKAXjB8/XpWVlers7Oy6r729Xdu3b5ckffTRR66WBjhDAQG94K677tLf//533X777Xrvvfe0b98+ffe731Vtba0kqaWlxfEKgd5HAQG9YPHixbr//vu1bt06XXXVVZo0aZKqq6t17733SpKGDh3qeIVA76OAgF7yk5/8RPX19Xr77be1d+9evfvuu4pGo5KkcePGOV4d0Pt4GTbg0LRp01RbW6sPPvhAcXF8P4iLC2c84MhLL72kd999V8uWLaN8cFHiCgjoBVu3btWjjz6q2bNna/jw4aqsrNSaNWv09a9/Xa+//roSEhJcLxHodZz1QC+45JJLFB8fr8cff1yNjY3Ky8vTY489puXLl1M+uGhxBQQAcIIfPAMAnKCAAABOUEAAACcoIACAExQQAMAJCggA4ESfewNCNBrV4cOHFQgE5PP5XC8HAGDJGKPGxkbl5OScdcpHnyugw4cPKzc31/UyAAAX6NChQxo5cuQZH+9zBRQIBCRJ1+obSlCi49UAAGx1KKJteqPr6/mZ9FgBrV69Wo8//rjq6uqUn5+vp556StOmTTtn7tMfuyUoUQk+CggA+p3/P1/nXE+j9MiLEF566SUtX75cK1eu1K5du5Sfn685c+boyJEjPbE7AEA/1CMF9MQTT+iOO+7Q9773PV155ZV69tlnNXjwYP3617/uid0BAPqhmBdQe3u7du7cqaKios92EhenoqIiVVRUnLJ9W1ubwuFwtxsAYOCLeQEdO3ZMnZ2dyszM7HZ/Zmam6urqTtm+tLRUwWCw68Yr4ADg4uD8jagrVqxQKBTquh06dMj1kgAAvSDmr4JLT09XfHy86uvru91fX1+vrKysU7b3+/3y+/2xXgYAoI+L+RVQUlKSpkyZos2bN3fdF41GtXnzZhUWFsZ6dwCAfqpH3ge0fPlyLVy4UF/5ylc0bdo0Pfnkk2pqatL3vve9ntgdAKAf6pECuuWWW3T06FE99NBDqqur09VXX61Nmzad8sIEAMDFy2eMMa4X8XnhcFjBYFAzNY9JCADQD3WYiMq0QaFQSCkpKWfczvmr4AAAFycKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgRILrBQB9is9nnzEm9us4jfjhadaZT+aM87SvlHWVnnLWPBxvX0KidcZE2q0zfZ6Xc9WrHjrHuQICADhBAQEAnKCAAABOUEAAACcoIACAExQQAMAJCggA4AQFBABwggICADhBAQEAnKCAAABOUEAAACcYRgp8ji8+3jpjOjqsM3FXX2md+ev3h9rvp8U6IklKbJpmnUloidrv5/c7rDO9OljUy7BUD+eQfPbXAr15HHwJdlXhM0Y6j08LroAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAmGkQKfYzt0UfI2jPTQnFTrzG2Fb1tn/nh0jHVGkj7wZ1lnTLL9fhKKCq0z457+yDrT8f5B64wkyRj7iIfzwYv4YcO8BTs77SPhsNX2xpzfMeAKCADgBAUEAHAi5gX08MMPy+fzdbtNmDAh1rsBAPRzPfIc0FVXXaW33nrrs514+Lk6AGBg65FmSEhIUFaW/ZOYAICLR488B7R//37l5ORozJgxuu2223Tw4JlfgdLW1qZwONztBgAY+GJeQAUFBVq7dq02bdqkZ555RjU1Nfra176mxsbG025fWlqqYDDYdcvNzY31kgAAfVDMC6i4uFjf+ta3NHnyZM2ZM0dvvPGGGhoa9PLLL592+xUrVigUCnXdDh06FOslAQD6oB5/dUBqaqrGjRunAwcOnPZxv98vv9/f08sAAPQxPf4+oBMnTqi6ulrZ2dk9vSsAQD8S8wL60Y9+pPLycr3//vv605/+pJtuuknx8fH69re/HetdAQD6sZj/CO7DDz/Ut7/9bR0/flwjRozQtddeq8rKSo0YMSLWuwIA9GMxL6AXX3wx1n8l0Guira29sp/2L52wzvxTcId1ZlBcxDojSeVxUevMR1vsX8HaOdn+OHzwRMA6E939VeuMJA3fZz+4M2V3rXXm2IxLrDNHp9gPSpWkzEr7zLC3qq22N9F26di5t2MWHADACQoIAOAEBQQAcIICAgA4QQEBAJyggAAATlBAAAAnKCAAgBMUEADACQoIAOAEBQQAcIICAgA40eO/kA5wwufzljP2Ax5P/LdrrDPfvbLMOlMdsZ8oPzLpY+uMJH0rZ6d96L/bZ35ZdZ11pukfQetM3BBvgzvrrrH/Hv2jefb/TybSYZ0Ztsvbl++4hfXWmXD7GKvtOyKt0obzWIv1SgAAiAEKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcYBo2epfXKdV92DX3vWOduX7oez2wklNdIm9ToJtMknWmoXOIdWbllf9pnTk6LmCdiRhvX+r+ff9XrTMnPEzrju+w/7y45n/sts5I0oK0d60zq347yWr7DhM5r+24AgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJxhGit5lvA3H7Mv2n8iwzhxPGWqdqetItc4Mjz9hnZGkQFyLdebSxGPWmaOd9oNF4xOj1pl2E2+dkaRHrnrdOtN6RaJ1JtHXaZ356qDD1hlJ+tZ737XODNE/PO3rXLgCAgA4QQEBAJyggAAATlBAAAAnKCAAgBMUEADACQoIAOAEBQQAcIICAgA4QQEBAJyggAAATlBAAAAnGEYKXKARfvuBn4N8EetMkq/DOnM4Msw6I0n7W8ZbZ/4eth/KOjfzL9aZiIfBovHyNgTXy5DQnMRPrDOtxn6Aqf0ZdNL0TPvBons87utcuAICADhBAQEAnLAuoK1bt+rGG29UTk6OfD6fXnvttW6PG2P00EMPKTs7W8nJySoqKtL+/ftjtV4AwABhXUBNTU3Kz8/X6tWrT/v4qlWr9Itf/ELPPvustm/friFDhmjOnDlqbW294MUCAAYO6xchFBcXq7i4+LSPGWP05JNP6oEHHtC8efMkSc8995wyMzP12muv6dZbb72w1QIABoyYPgdUU1Ojuro6FRUVdd0XDAZVUFCgioqK02ba2toUDoe73QAAA19MC6iurk6SlJmZ2e3+zMzMrse+qLS0VMFgsOuWm5sbyyUBAPoo56+CW7FihUKhUNft0KFDrpcEAOgFMS2grKwsSVJ9fX23++vr67se+yK/36+UlJRuNwDAwBfTAsrLy1NWVpY2b97cdV84HNb27dtVWFgYy10BAPo561fBnThxQgcOHOj6uKamRnv27FFaWppGjRqlZcuW6bHHHtPll1+uvLw8Pfjgg8rJydH8+fNjuW4AQD9nXUA7duzQ9ddf3/Xx8uXLJUkLFy7U2rVrde+996qpqUl33nmnGhoadO2112rTpk0aNGhQ7FYNAOj3fMYYb1P6ekg4HFYwGNRMzVOCz35AH/o4n88+Em8/fNJ02A/ulKT4YfbDO2+t+LP9fnz2n3ZHOwLWmdT4ZuuMJJU32A8j/cvx0z/PezaPjv8P68yu5kutMzlJ9gNCJW/H7/32dOvM5f7Tv0r4bH73Sb51RpJyB31snfn9shlW23d0tGpb2SMKhUJnfV7f+avgAAAXJwoIAOAEBQQAcIICAgA4QQEBAJyggAAATlBAAAAnKCAAgBMUEADACQoIAOAEBQQAcIICAgA4QQEBAJyw/nUMwAXxMHzdl2B/mnqdhn3o9iusMzcMft0686fWS6wzIxIarTMRYz9JXJKy/SHrTCCz1TrT0DnYOpOWcMI609iZbJ2RpMFxbdYZL/9PX046Zp25560vW2ckKTDxuHUmJdHuWiV6ntc2XAEBAJyggAAATlBAAAAnKCAAgBMUEADACQoIAOAEBQQAcIICAgA4QQEBAJyggAAATlBAAAAnKCAAgBMMI0Wv8iUmWWeirfZDLr1K/3O7deZYZ6J1JjWu2TqT5Ou0zrR7HEb61bQa68xRDwM/d7XkWWcC8S3WmRFx9gNCJSk30X5w559bc60zbzRdZp25/b+8ZZ2RpBf+99etM0mb/mS1fZyJnN921isBACAGKCAAgBMUEADACQoIAOAEBQQAcIICAgA4QQEBAJyggAAATlBAAAAnKCAAgBMUEADACQoIAODExT2M1OfzFkuwHz7pi/fQ9XH2mWhrm/1+ovZDLr0yEfthn73pf/6vX1pnDnWkWmfqIvaZ1Hj7Aaad8naOV7YErTOD4s5vAOXnjUgIW2fCUfuhp141RgdZZyIeBsB6OXb3Dd9vnZGkV0NFnnI9gSsgAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHBiwAwj9SXY/1NMR4enfXkZqGnsZw0OSC3zpllnDs23H5Z625fesc5IUl1HwDqzu/lS60wwvsU6MyTOftBsq7EfnCtJh9uHWWe8DNRMSzhhncnwMMC003j7XvujiP1x8MLLoNkPO+yPnSQ1/tdG60zqc552dU5cAQEAnKCAAABOWBfQ1q1bdeONNyonJ0c+n0+vvfZat8cXLVokn8/X7TZ37txYrRcAMEBYF1BTU5Py8/O1evXqM24zd+5c1dbWdt1eeOGFC1okAGDgsX7mvri4WMXFxWfdxu/3Kysry/OiAAADX488B1RWVqaMjAyNHz9eS5Ys0fHjx8+4bVtbm8LhcLcbAGDgi3kBzZ07V88995w2b96sn/3sZyovL1dxcbE6O0//UtrS0lIFg8GuW25ubqyXBADog2L+PqBbb72168+TJk3S5MmTNXbsWJWVlWnWrFmnbL9ixQotX7686+NwOEwJAcBFoMdfhj1mzBilp6frwIEDp33c7/crJSWl2w0AMPD1eAF9+OGHOn78uLKzs3t6VwCAfsT6R3AnTpzodjVTU1OjPXv2KC0tTWlpaXrkkUe0YMECZWVlqbq6Wvfee68uu+wyzZkzJ6YLBwD0b9YFtGPHDl1//fVdH3/6/M3ChQv1zDPPaO/evfrNb36jhoYG5eTkaPbs2frxj38sv98fu1UDAPo9nzHGuF7E54XDYQWDQc3UPCX4vA1S7IsSsu3fFxXJy7TOfHzFYOtMc5bPOiNJV3/jr9aZRZnbrDNHO+2fF0z0eRs029iZbJ3JSmywzmwJXWmdGZpgP4zUy9BTSfpy8vvWmYao/bmXk/CJdea+A/9knckcbD+AU5L+ffQb1pmIiVpnqiL236AH4uyHIkvS282XWWfWXznCavsOE1GZNigUCp31eX1mwQEAnKCAAABOUEAAACcoIACAExQQAMAJCggA4AQFBABwggICADhBAQEAnKCAAABOUEAAACcoIACAExQQAMCJmP9KblfaiqdaZzL+5R+e9nV1yofWmSuT7adAt0btp4EPiotYZ95rucQ6I0nN0STrzP52+6ngoQ77KcvxPvuJxJJ0pD1gnfm3miLrzOZpz1pnHjg81zoTl+xt2P3xzqHWmQVDwx72ZH+Of3/UVuvMmKQj1hlJ2thk/4s0D0eGWWcyE0PWmUsTj1pnJOnmwN+tM+tlNw37fHEFBABwggICADhBAQEAnKCAAABOUEAAACcoIACAExQQAMAJCggA4AQFBABwggICADhBAQEAnKCAAABO9NlhpL6EBPl857+8gn9913ofswJ/sc5IUrPxW2e8DBb1MtTQi2BCs6dcW8T+9DkSSfG0L1vj/HWecjel7LHObP1lgXXm2ta7rTPVN6yxzmxuibfOSNLRDvv/p1trbrDO7DqYa5255tIa68ykwEfWGcnbINxAfKt1JtHXYZ1pitp/HZKkylb7QbM9hSsgAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCizw4jrV0yRfH+Qee9/cPBp6z3se7ja6wzkpQ76GPrzOikY9aZ/OQPrDNeBOLshydK0vgU+wGKG5tGWmfKGiZYZ7ITG6wzkvR281jrzIsPP26dWXTPD60zhW8sts6EL/X2PWbHEGOdSck/bp154Ev/aZ1J8nVaZxo67YeKSlKav8k6kxrvbbivLS9DkSUpENdinYkff5nV9qazTdp/7u24AgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJ/rsMNLBR6KKT4qe9/Ybw1db72NM8lHrjCQdiwSsM//nxCTrzMjkT6wzwXj7QYOX+eusM5K0pzXVOrPp6FXWmZzksHWmPhK0zkjS8cgQ60xz1H4o5K9+/oR15t/qi6wzN6Xtss5IUn6S/WDRhqj997PvtWdZZxqj5z+k+FOtJtE6I0khD0NMAx4+ByPG/ktxvDn/r4+flxpnPyw1PGm41fYdkVaGkQIA+i4KCADghFUBlZaWaurUqQoEAsrIyND8+fNVVVXVbZvW1laVlJRo+PDhGjp0qBYsWKD6+vqYLhoA0P9ZFVB5eblKSkpUWVmpN998U5FIRLNnz1ZT02e/tOmee+7R66+/rldeeUXl5eU6fPiwbr755pgvHADQv1k987Vp06ZuH69du1YZGRnauXOnZsyYoVAopF/96ldat26dbrjhBknSmjVrdMUVV6iyslLXXOPtN5ACAAaeC3oOKBQKSZLS0tIkSTt37lQkElFR0Wev1pkwYYJGjRqlioqK0/4dbW1tCofD3W4AgIHPcwFFo1EtW7ZM06dP18SJEyVJdXV1SkpKUmpqardtMzMzVVd3+pf6lpaWKhgMdt1yc3O9LgkA0I94LqCSkhLt27dPL7744gUtYMWKFQqFQl23Q4cOXdDfBwDoHzy9EXXp0qXauHGjtm7dqpEjR3bdn5WVpfb2djU0NHS7Cqqvr1dW1unfcOb3++X327+RDwDQv1ldARljtHTpUq1fv15btmxRXl5et8enTJmixMREbd68ueu+qqoqHTx4UIWFhbFZMQBgQLC6AiopKdG6deu0YcMGBQKBrud1gsGgkpOTFQwGdfvtt2v58uVKS0tTSkqK7r77bhUWFvIKOABAN1YF9Mwzz0iSZs6c2e3+NWvWaNGiRZKkn//854qLi9OCBQvU1tamOXPm6Omnn47JYgEAA4fPGGNcL+LzwuGwgsGgZlz7oBISzn/o4NQnd1rva184xzojSZmDGq0zk4d+aJ2parYf1Hi4JcU6MzghYp2RpOR4+1yHsX/dS4bf/niP8tsP05SkQJz9IMkkX6d1ptPD63+uSjpsnTnYMcw6I0l1HanWmfea7T+fhiXYD8b8s4fP2+aOJOuMJLV12j9N3tphnwn6W60zU9M+sM5IUpzsv+Sv+4/rrLaPtrbqH4/9i0KhkFJSzvw1iVlwAAAnKCAAgBMUEADACQoIAOAEBQQAcIICAgA4QQEBAJyggAAATlBAAAAnKCAAgBMUEADACQoIAOAEBQQAcMLTb0TtDXHb9irOl3je27/y++nW+3hw3ivWGUkqb5hgndlYN8k6E263/02xIwY3WWdSEu2nTUtSWqL9voIeph8P8nVYZz7pGGKdkaS2uPM/5z7VKZ91pq4taJ35Y/Ry60wkGm+dkaQ2Dzkv09E/bk+3zuQkh6wzjR3nP1n/895vTLPOHAsNtc60Drb/Urytc6x1RpLmZv3FOpN8xO4c72w7v+25AgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJ3zGGON6EZ8XDocVDAY1U/OUYDGM1IvQbdd4yo25q8o6My21xjqzKzzKOnPQw/DESNTb9yGJcVHrzODEduvMIA9DLpPiO60zkhQn+0+HqIdhpEPi7Y/DkIQ260xKQqt1RpIC8fa5OJ/9+eBFvIf/o3dCl8Z+IWcQ8PD/1GHsPwcLg9XWGUn6dc1XrTPBbxyw2r7DRFSmDQqFQkpJSTnjdlwBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATfXcYadzNdsNIo96GT/aWpgUF1pmC+9+1zwTsBxROSKq3zkhSouyHTw7yMLBySJz9sM9Wj6e1l+/ItrXkWmc6PexpyydXWGciHoZcSlJ985kHSJ5JoscBsLaixv58aOnwNtg41DLIOhMfZ3/utZalW2eGv2c/pFeS/G/Yf12xxTBSAECfRgEBAJyggAAATlBAAAAnKCAAgBMUEADACQoIAOAEBQQAcIICAgA4QQEBAJyggAAATlBAAAAn+u4wUs2zG0YKz3xTJ3nKtWQlW2f8x9usM42j7feTUt1knZGkuLYO60z0//7V076AgYphpACAPo0CAgA4YVVApaWlmjp1qgKBgDIyMjR//nxVVVV122bmzJny+XzdbosXL47pogEA/Z9VAZWXl6ukpESVlZV68803FYlENHv2bDU1df95+x133KHa2tqu26pVq2K6aABA/5dgs/GmTZu6fbx27VplZGRo586dmjFjRtf9gwcPVlZWVmxWCAAYkC7oOaBQKCRJSktL63b/888/r/T0dE2cOFErVqxQc3PzGf+OtrY2hcPhbjcAwMBndQX0edFoVMuWLdP06dM1ceLErvu/853vaPTo0crJydHevXt13333qaqqSq+++upp/57S0lI98sgjXpcBAOinPL8PaMmSJfrd736nbdu2aeTIkWfcbsuWLZo1a5YOHDigsWPHnvJ4W1ub2to+e29IOBxWbm4u7wPqRbwP6DO8Dwi4cOf7PiBPV0BLly7Vxo0btXXr1rOWjyQVFBRI0hkLyO/3y+/3e1kGAKAfsyogY4zuvvturV+/XmVlZcrLyztnZs+ePZKk7OxsTwsEAAxMVgVUUlKidevWacOGDQoEAqqrq5MkBYNBJScnq7q6WuvWrdM3vvENDR8+XHv37tU999yjGTNmaPLkyT3yDwAA9E9WBfTMM89IOvlm089bs2aNFi1apKSkJL311lt68skn1dTUpNzcXC1YsEAPPPBAzBYMABgYrH8Edza5ubkqLy+/oAUBAC4Onl+GjYHDvPtnT7lBMV7HmaT8qZd2JCnae7sCLnoMIwUAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHCCAgIAOEEBAQCcoIAAAE5QQAAAJyggAIATFBAAwAkKCADgBAUEAHAiwfUCvsgYI0nqUEQyjhcDALDWoYikz76en0mfK6DGxkZJ0ja94XglAIAL0djYqGAweMbHfeZcFdXLotGoDh8+rEAgIJ/P1+2xcDis3NxcHTp0SCkpKY5W6B7H4SSOw0kch5M4Dif1heNgjFFjY6NycnIUF3fmZ3r63BVQXFycRo4cedZtUlJSLuoT7FMch5M4DidxHE7iOJzk+jic7crnU7wIAQDgBAUEAHCiXxWQ3+/XypUr5ff7XS/FKY7DSRyHkzgOJ3EcTupPx6HPvQgBAHBx6FdXQACAgYMCAgA4QQEBAJyggAAATlBAAAAn+k0BrV69WpdeeqkGDRqkgoICvfPOO66X1Osefvhh+Xy+brcJEya4XlaP27p1q2688Ubl5OTI5/Pptdde6/a4MUYPPfSQsrOzlZycrKKiIu3fv9/NYnvQuY7DokWLTjk/5s6d62axPaS0tFRTp05VIBBQRkaG5s+fr6qqqm7btLa2qqSkRMOHD9fQoUO1YMEC1dfXO1pxzzif4zBz5sxTzofFixc7WvHp9YsCeumll7R8+XKtXLlSu3btUn5+vubMmaMjR464Xlqvu+qqq1RbW9t127Ztm+sl9bimpibl5+dr9erVp3181apV+sUvfqFnn31W27dv15AhQzRnzhy1trb28kp71rmOgyTNnTu32/nxwgsv9OIKe155eblKSkpUWVmpN998U5FIRLNnz1ZTU1PXNvfcc49ef/11vfLKKyovL9fhw4d18803O1x17J3PcZCkO+64o9v5sGrVKkcrPgPTD0ybNs2UlJR0fdzZ2WlycnJMaWmpw1X1vpUrV5r8/HzXy3BKklm/fn3Xx9Fo1GRlZZnHH3+8676Ghgbj9/vNCy+84GCFveOLx8EYYxYuXGjmzZvnZD2uHDlyxEgy5eXlxpiT//eJiYnmlVde6drmr3/9q5FkKioqXC2zx33xOBhjzHXXXWd+8IMfuFvUeejzV0Dt7e3auXOnioqKuu6Li4tTUVGRKioqHK7Mjf379ysnJ0djxozRbbfdpoMHD7peklM1NTWqq6vrdn4Eg0EVFBRclOdHWVmZMjIyNH78eC1ZskTHjx93vaQeFQqFJElpaWmSpJ07dyoSiXQ7HyZMmKBRo0YN6PPhi8fhU88//7zS09M1ceJErVixQs3NzS6Wd0Z9bhr2Fx07dkydnZ3KzMzsdn9mZqb+9re/OVqVGwUFBVq7dq3Gjx+v2tpaPfLII/ra176mffv2KRAIuF6eE3V1dZJ02vPj08cuFnPnztXNN9+svLw8VVdX6/7771dxcbEqKioUHx/venkxF41GtWzZMk2fPl0TJ06UdPJ8SEpKUmpqardtB/L5cLrjIEnf+c53NHr0aOXk5Gjv3r267777VFVVpVdffdXharvr8wWEzxQXF3f9efLkySooKNDo0aP18ssv6/bbb3e4MvQFt956a9efJ02apMmTJ2vs2LEqKyvTrFmzHK6sZ5SUlGjfvn0XxfOgZ3Om43DnnXd2/XnSpEnKzs7WrFmzVF1drbFjx/b2Mk+rz/8ILj09XfHx8ae8iqW+vl5ZWVmOVtU3pKamaty4cTpw4IDrpTjz6TnA+XGqMWPGKD09fUCeH0uXLtXGjRv1hz/8odvvD8vKylJ7e7saGhq6bT9Qz4czHYfTKSgokKQ+dT70+QJKSkrSlClTtHnz5q77otGoNm/erMLCQocrc+/EiROqrq5Wdna266U4k5eXp6ysrG7nRzgc1vbt2y/68+PDDz/U8ePHB9T5YYzR0qVLtX79em3ZskV5eXndHp8yZYoSExO7nQ9VVVU6ePDggDofznUcTmfPnj2S1LfOB9evgjgfL774ovH7/Wbt2rXmvffeM3feeadJTU01dXV1rpfWq374wx+asrIyU1NTY/74xz+aoqIik56ebo4cOeJ6aT2qsbHR7N692+zevdtIMk888YTZvXu3+eCDD4wxxvz0pz81qampZsOGDWbv3r1m3rx5Ji8vz7S0tDheeWyd7Tg0NjaaH/3oR6aiosLU1NSYt956y3z5y182l19+uWltbXW99JhZsmSJCQaDpqyszNTW1nbdmpubu7ZZvHixGTVqlNmyZYvZsWOHKSwsNIWFhQ5XHXvnOg4HDhwwjz76qNmxY4epqakxGzZsMGPGjDEzZsxwvPLu+kUBGWPMU089ZUaNGmWSkpLMtGnTTGVlpesl9bpbbrnFZGdnm6SkJHPJJZeYW265xRw4cMD1snrcH/7wByPplNvChQuNMSdfiv3ggw+azMxM4/f7zaxZs0xVVZXbRfeAsx2H5uZmM3v2bDNixAiTmJhoRo8ebe64444B903a6f79ksyaNWu6tmlpaTF33XWXGTZsmBk8eLC56aabTG1trbtF94BzHYeDBw+aGTNmmLS0NOP3+81ll11m/vmf/9mEQiG3C/8Cfh8QAMCJPv8cEABgYKKAAABOUEAAACcoIACAExQQAMAJCggA4AQFBABwggICADhBAQEAnKCAAABOUEAAACf+H0hWZu+uQDy3AAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "the image is little blur , lets make it human readable"
+      ],
+      "metadata": {
+        "id": "kYqogoJXjVEl"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "plt.imshow(image.squeeze(), cmap=\"gray\")\n",
+        "plt.title(class_names[label])\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 469
+        },
+        "id": "4bD-jWUWjc9k",
+        "outputId": "14140ce8-cc7d-4c90-c07d-304e17330392"
+      },
+      "execution_count": 36,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Text(0.5, 1.0, 'Ankle boot')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 36
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAGzCAYAAABpdMNsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAKJhJREFUeJzt3Xt0VeWdxvHnJCSHQJLDJeRWAgk3YeSigxAjco9AtAwUrHhZs6CDWpnQFtCxi5lW6rRrUrFjWVQqttMF1okizuJSXUqHi4QqIAVh0BllCAYBQ8Kl5iQk5ELyzh8sz3i4hXeb5E3C97PWXnL2eX/ZLy87edw5+/yOzxhjBABAC4twPQEAwI2JAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIaMWfOHMXGxjY6bty4cRo3blyTHXfcuHEaPHhwk309oLUhgNAu/frXv5bP51NmZqbrqbRJ//Iv/6INGza4ngbaOQII7VJ+fr7S09O1Z88eFRYWup5Om0MAoSUQQGh3ioqKtHPnTj333HPq0aOH8vPzXU8JwBUQQGh38vPz1bVrV91zzz269957rxhAR48elc/n0y9+8Qv95je/Ud++feX3+zVixAj9+c9/bvQYBw4cUI8ePTRu3DidO3fuquNqamq0ZMkS9evXT36/X2lpaXryySdVU1Nz3X+fffv26Y477lBMTIwyMjK0cuXKy8acOnVKc+fOVVJSkjp27Khhw4bppZdeumxcZWWlHn/8caWlpcnv9+umm27SL37xC321Kb7P51NlZaVeeukl+Xw++Xw+zZkz57rnC1w3A7QzAwcONHPnzjXGGLNjxw4jyezZsydsTFFRkZFkbr31VtOvXz/zzDPPmKVLl5qEhATTs2dPU1tbGxo7e/Zs07lz59DjPXv2mK5du5q77rrLVFVVhfaPHTvWjB07NvS4vr7eTJo0yXTq1MksWLDAvPjii2b+/PmmQ4cOZtq0aY3+PcaOHWtSU1NNYmKimT9/vlm+fLm58847jSTzu9/9LjSuqqrKDBo0yERFRZmFCxea5cuXm9GjRxtJZtmyZaFxDQ0NZsKECcbn85mHH37YPP/882bq1KlGklmwYEFo3Msvv2z8fr8ZPXq0efnll83LL79sdu7c2fjCA5YIILQre/fuNZLM5s2bjTEXf+j27NnT/OAHPwgb92UAde/e3fzlL38J7d+4caORZN54443Qvq8G0Lvvvmvi4+PNPffcY6qrq8O+5qUB9PLLL5uIiAjzpz/9KWzcypUrjSTz3nvvXfPvMnbsWCPJ/Ou//mtoX01NjbnllltMYmJiKCSXLVtmJJl///d/D42rra01WVlZJjY21pSXlxtjjNmwYYORZH72s5+FHefee+81Pp/PFBYWhvZ17tzZzJ49+5rzA74ufgWHdiU/P19JSUkaP368pIu/Tpo1a5bWrFmj+vr6y8bPmjVLXbt2DT0ePXq0JOnTTz+9bOw777yjyZMna+LEiVq3bp38fv815/L6669r0KBBGjhwoM6cORPaJkyYEPp6jenQoYO++93vhh5HR0fru9/9rk6dOqV9+/ZJkt566y0lJyfrgQceCI2LiorS97//fZ07d04FBQWhcZGRkfr+978fdozHH39cxhi9/fbbjc4HaEoEENqN+vp6rVmzRuPHj1dRUZEKCwtVWFiozMxMlZaWauvWrZfV9OrVK+zxl2H0xRdfhO2vrq7WPffco1tvvVVr165VdHR0o/M5fPiw/vu//1s9evQI2wYMGCDp4us2jUlNTVXnzp3D9n1Zf/ToUUnSZ599pv79+ysiIvzbedCgQaHnv/xvamqq4uLirjkOaCkdXE8AaCrbtm3TyZMntWbNGq1Zs+ay5/Pz8zVp0qSwfZGRkVf8WuaST6r3+/26++67tXHjRm3atEnf/OY3G51PQ0ODhgwZoueee+6Kz6elpTX6NYD2jABCu5Gfn6/ExEStWLHisufWrVun9evXa+XKlYqJibH+2j6fT/n5+Zo2bZq+/e1v6+23326060Hfvn31X//1X5o4caJ8Pp/1MSWpuLhYlZWVYVdB//u//ytJSk9PlyT17t1bBw8eVENDQ9hV0CeffBJ6/sv/btmyRRUVFWFXQZeO+/LvCzQ3fgWHduH8+fNat26dvvnNb+ree++9bJs/f74qKir0hz/8wfMxoqOjtW7dOo0YMUJTp07Vnj17rjn+vvvu0+eff67f/va3V5xvZWVlo8e8cOGCXnzxxdDj2tpavfjii+rRo4eGDx8uSbr77rtVUlKi1157LazuV7/6lWJjYzV27NjQuPr6ej3//PNhx/jlL38pn8+nnJyc0L7OnTurrKys0fkBXwdXQGgX/vCHP6iiokJ/8zd/c8Xnb7/99tCbUmfNmuX5ODExMXrzzTc1YcIE5eTkqKCg4Kr92v72b/9Wa9eu1WOPPaZ33nlHo0aNUn19vT755BOtXbtWf/zjH3Xbbbdd83ipqal65plndPToUQ0YMECvvfaaDhw4oN/85jeKioqSJD366KN68cUXNWfOHO3bt0/p6en6j//4D7333ntatmxZ6Gpn6tSpGj9+vP7pn/5JR48e1bBhw/Sf//mf2rhxoxYsWKC+ffuGjjt8+HBt2bJFzz33nFJTU5WRkUFbIzQ917fhAU1h6tSppmPHjqaysvKqY+bMmWOioqLMmTNnQrdhP/vss5eNk2SWLFkSenzp+4CMMebMmTPmr/7qr0xycrI5fPiwMeby27CNuXg79DPPPGNuvvlm4/f7TdeuXc3w4cPN008/bYLB4DX/TmPHjjU333yz2bt3r8nKyjIdO3Y0vXv3Ns8///xlY0tLS813vvMdk5CQYKKjo82QIUPMqlWrLhtXUVFhFi5caFJTU01UVJTp37+/efbZZ01DQ0PYuE8++cSMGTPGxMTEGEncko1m4TPmkldbAQBoAbwGBABwggACADhBAAEAnCCAAABOEEAAACcIIACAE63ujagNDQ0qLi5WXFwc7UAAoA0yxqiiokKpqamXNcn9qlYXQMXFxTRpBIB24Pjx4+rZs+dVn291v4K7tFU8AKBtauznebMF0IoVK5Senq6OHTsqMzOz0caNX+LXbgDQPjT287xZAui1117TokWLtGTJEn3wwQcaNmyYJk+efF0fwAUAuEE0R4O5kSNHmtzc3NDj+vp6k5qaavLy8hqtDQaDRhIbGxsbWxvfGmu42+RXQLW1tdq3b5+ys7ND+yIiIpSdna1du3ZdNr6mpkbl5eVhGwCg/WvyADpz5ozq6+uVlJQUtj8pKUklJSWXjc/Ly1MgEAht3AEHADcG53fBLV68WMFgMLQdP37c9ZQAAC2gyd8HlJCQoMjISJWWlobtLy0tVXJy8mXj/X6//H5/U08DANDKNfkVUHR0tIYPH66tW7eG9jU0NGjr1q3Kyspq6sMBANqoZumEsGjRIs2ePVu33XabRo4cqWXLlqmyslLf+c53muNwAIA2qFkCaNasWTp9+rSeeuoplZSU6JZbbtGmTZsuuzEBAHDj8hljjOtJfFV5ebkCgYDraQAAvqZgMKj4+PirPu/8LjgAwI2JAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAONHB9QSA1sTn81nXGGOaYSaXi4uLs6658847PR3r7bff9lRny8t6R0ZGWtdcuHDBuqa187J2XjXXOc4VEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA4QTNS4CsiIuz/n6y+vt66pl+/ftY1Dz/8sHXN+fPnrWskqbKy0rqmurraumbPnj3WNS3ZWNRLw08v55CX47TkOtg2gDXGqKGhodFxXAEBAJwggAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBM0IwW+wrbpouStGemECROsa7Kzs61rTpw4YV0jSX6/37qmU6dO1jV33XWXdc2//du/WdeUlpZa10gXm2ra8nI+eBEbG+up7nqahF6qqqrK07EawxUQAMAJAggA4ESTB9BPfvIT+Xy+sG3gwIFNfRgAQBvXLK8B3XzzzdqyZcv/H6QDLzUBAMI1SzJ06NBBycnJzfGlAQDtRLO8BnT48GGlpqaqT58+euihh3Ts2LGrjq2pqVF5eXnYBgBo/5o8gDIzM7V69Wpt2rRJL7zwgoqKijR69GhVVFRccXxeXp4CgUBoS0tLa+opAQBaoSYPoJycHH3729/W0KFDNXnyZL311lsqKyvT2rVrrzh+8eLFCgaDoe348eNNPSUAQCvU7HcHdOnSRQMGDFBhYeEVn/f7/Z7e9AYAaNua/X1A586d05EjR5SSktLchwIAtCFNHkBPPPGECgoKdPToUe3cuVPf+ta3FBkZqQceeKCpDwUAaMOa/FdwJ06c0AMPPKCzZ8+qR48euvPOO7V792716NGjqQ8FAGjDmjyA1qxZ09RfEmgxtbW1LXKcESNGWNekp6db13hpripJERH2vxz54x//aF1z6623WtcsXbrUumbv3r3WNZL04YcfWtd8/PHH1jUjR460rvFyDknSzp07rWt27dplNd4Yc11vqaEXHADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA40ewfSAe44PP5PNUZY6xr7rrrLuua2267zbrmah9rfy2dO3e2rpGkAQMGtEjNn//8Z+uaq3245bXExsZa10hSVlaWdc2MGTOsa+rq6qxrvKydJD388MPWNTU1NVbjL1y4oD/96U+NjuMKCADgBAEEAHCCAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAOEEAAQCcIIAAAE74jJf2v82ovLxcgUDA9TTQTLx2qW4pXr4ddu/ebV2Tnp5uXeOF1/W+cOGCdU1tba2nY9mqrq62rmloaPB0rA8++MC6xku3bi/rPWXKFOsaSerTp491zTe+8Q1PxwoGg4qPj7/q81wBAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATHVxPADeWVtb7tkl88cUX1jUpKSnWNefPn7eu8fv91jWS1KGD/Y+G2NhY6xovjUVjYmKsa7w2Ix09erR1zR133GFdExFhfy2QmJhoXSNJmzZt8lTXHLgCAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnaEYKfE2dOnWyrvHSfNJLTVVVlXWNJAWDQeuas2fPWtekp6db13hpaOvz+axrJG9r7uV8qK+vt67x2mA1LS3NU11z4AoIAOAEAQQAcMI6gHbs2KGpU6cqNTVVPp9PGzZsCHveGKOnnnpKKSkpiomJUXZ2tg4fPtxU8wUAtBPWAVRZWalhw4ZpxYoVV3x+6dKlWr58uVauXKn3339fnTt31uTJkz198BQAoP2yvgkhJydHOTk5V3zOGKNly5bpRz/6kaZNmyZJ+v3vf6+kpCRt2LBB999//9ebLQCg3WjS14CKiopUUlKi7Ozs0L5AIKDMzEzt2rXrijU1NTUqLy8P2wAA7V+TBlBJSYkkKSkpKWx/UlJS6LlL5eXlKRAIhLbWdIsgAKD5OL8LbvHixQoGg6Ht+PHjrqcEAGgBTRpAycnJkqTS0tKw/aWlpaHnLuX3+xUfHx+2AQDavyYNoIyMDCUnJ2vr1q2hfeXl5Xr//feVlZXVlIcCALRx1nfBnTt3ToWFhaHHRUVFOnDggLp166ZevXppwYIF+tnPfqb+/fsrIyNDP/7xj5Wamqrp06c35bwBAG2cdQDt3btX48ePDz1etGiRJGn27NlavXq1nnzySVVWVurRRx9VWVmZ7rzzTm3atEkdO3ZsulkDANo8n/HS2a8ZlZeXKxAIuJ4GmomXppBeGkJ6ae4oSbGxsdY1+/fvt67xsg7nz5+3rvH7/dY1klRcXGxdc+lrv9fjjjvusK7x0vTUS4NQSYqOjrauqaiosK7x8jPP6w1bXs7xuXPnWo2vr6/X/v37FQwGr/m6vvO74AAANyYCCADgBAEEAHCCAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAOEEAAQCcsP44BuDr8NJ8PTIy0rrGazfsWbNmWddc7dN+r+X06dPWNTExMdY1DQ0N1jWS1LlzZ+uatLQ065ra2lrrGi8dvuvq6qxrJKlDB/sfkV7+nbp3725ds2LFCusaSbrlllusa7ysw/XgCggA4AQBBABwggACADhBAAEAnCCAAABOEEAAACcIIACAEwQQAMAJAggA4AQBBABwggACADhBAAEAnKAZKVqUl6aGXhpWevXRRx9Z19TU1FjXREVFWde0ZFPWxMRE65rq6mrrmrNnz1rXeFm7jh07WtdI3pqyfvHFF9Y1J06csK558MEHrWsk6dlnn7Wu2b17t6djNYYrIACAEwQQAMAJAggA4AQBBABwggACADhBAAEAnCCAAABOEEAAACcIIACAEwQQAMAJAggA4AQBBABw4oZuRurz+TzVeWkKGRFhn/Ve5ldXV2dd09DQYF3j1YULF1rsWF689dZb1jWVlZXWNefPn7euiY6Otq4xxljXSNLp06eta7x8X3hpEurlHPeqpb6fvKzd0KFDrWskKRgMeqprDlwBAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAOEEAAQCcIIAAAE4QQAAAJwggAIAT7aYZqZdmfvX19Z6O1dobarZmY8aMsa6ZOXOmdc2oUaOsaySpqqrKuubs2bPWNV4ai3boYP/t6vUc97IOXr4H/X6/dY2XBqZem7J6WQcvvJwP586d83SsGTNmWNe88cYbno7VGK6AAABOEEAAACesA2jHjh2aOnWqUlNT5fP5tGHDhrDn58yZI5/PF7ZNmTKlqeYLAGgnrAOosrJSw4YN04oVK646ZsqUKTp58mRoe/XVV7/WJAEA7Y/1q5o5OTnKycm55hi/36/k5GTPkwIAtH/N8hrQ9u3blZiYqJtuuknz5s275l1CNTU1Ki8vD9sAAO1fkwfQlClT9Pvf/15bt27VM888o4KCAuXk5Fz1dtC8vDwFAoHQlpaW1tRTAgC0Qk3+PqD7778/9OchQ4Zo6NCh6tu3r7Zv366JEydeNn7x4sVatGhR6HF5eTkhBAA3gGa/DbtPnz5KSEhQYWHhFZ/3+/2Kj48P2wAA7V+zB9CJEyd09uxZpaSkNPehAABtiPWv4M6dOxd2NVNUVKQDBw6oW7du6tatm55++mnNnDlTycnJOnLkiJ588kn169dPkydPbtKJAwDaNusA2rt3r8aPHx96/OXrN7Nnz9YLL7yggwcP6qWXXlJZWZlSU1M1adIk/fSnP/XU8wkA0H75jNcufc2kvLxcgUDA9TSaXLdu3axrUlNTrWv69+/fIseRvDU1HDBggHVNTU2NdU1EhLffLtfV1VnXxMTEWNcUFxdb10RFRVnXeGlyKUndu3e3rqmtrbWu6dSpk3XNzp07rWtiY2OtayRvzXMbGhqsa4LBoHWNl/NBkkpLS61rBg0a5OlYwWDwmq/r0wsOAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAATjT5R3K7cvvtt1vX/PSnP/V0rB49eljXdOnSxbqmvr7euiYyMtK6pqyszLpGki5cuGBdU1FRYV3jpcuyz+ezrpGk8+fPW9d46c583333Wdfs3bvXuiYuLs66RvLWgTw9Pd3TsWwNGTLEusbrOhw/fty6pqqqyrrGS0d1rx2+e/fu7amuOXAFBABwggACADhBAAEAnCCAAABOEEAAACcIIACAEwQQAMAJAggA4AQBBABwggACADhBAAEAnCCAAABOtNpmpBEREVYNJZcvX259jJSUFOsayVuTUC81XpoaehEdHe2pzsvfyUuzTy8CgYCnOi+NGn/+859b13hZh3nz5lnXFBcXW9dIUnV1tXXN1q1brWs+/fRT65r+/ftb13Tv3t26RvLWCDcqKsq6JiLC/lqgrq7OukaSTp8+7amuOXAFBABwggACADhBAAEAnCCAAABOEEAAACcIIACAEwQQAMAJAggA4AQBBABwggACADhBAAEAnCCAAABO+IwxxvUkvqq8vFyBQEAPPfSQVZNMLw0hjxw5Yl0jSbGxsS1S4/f7rWu88NI8UfLW8PP48ePWNV4aavbo0cO6RvLWFDI5Odm6Zvr06dY1HTt2tK5JT0+3rpG8na/Dhw9vkRov/0Zemop6PZbX5r62bJo1f5WX7/fbb7/danxDQ4M+//xzBYNBxcfHX3UcV0AAACcIIACAEwQQAMAJAggA4AQBBABwggACADhBAAEAnCCAAABOEEAAACcIIACAEwQQAMAJAggA4EQH1xO4mtOnT1s1zfPS5DIuLs66RpJqamqsa7zMz0tDSC+NEK/VLPBa/vKXv1jXfPbZZ9Y1Xtbh/Pnz1jWSVF1dbV1z4cIF65r169db13z44YfWNV6bkXbr1s26xkvDz7KyMuuauro66xov/0bSxaaatrw0+/RyHK/NSL38jBgwYIDV+AsXLujzzz9vdBxXQAAAJwggAIATVgGUl5enESNGKC4uTomJiZo+fboOHToUNqa6ulq5ubnq3r27YmNjNXPmTJWWljbppAEAbZ9VABUUFCg3N1e7d+/W5s2bVVdXp0mTJqmysjI0ZuHChXrjjTf0+uuvq6CgQMXFxZoxY0aTTxwA0LZZ3YSwadOmsMerV69WYmKi9u3bpzFjxigYDOp3v/udXnnlFU2YMEGStGrVKg0aNEi7d++2/lQ9AED79bVeAwoGg5L+/46Zffv2qa6uTtnZ2aExAwcOVK9evbRr164rfo2amhqVl5eHbQCA9s9zADU0NGjBggUaNWqUBg8eLEkqKSlRdHS0unTpEjY2KSlJJSUlV/w6eXl5CgQCoS0tLc3rlAAAbYjnAMrNzdVHH32kNWvWfK0JLF68WMFgMLR5eb8MAKDt8fRG1Pnz5+vNN9/Ujh071LNnz9D+5ORk1dbWqqysLOwqqLS0VMnJyVf8Wn6/X36/38s0AABtmNUVkDFG8+fP1/r167Vt2zZlZGSEPT98+HBFRUVp69atoX2HDh3SsWPHlJWV1TQzBgC0C1ZXQLm5uXrllVe0ceNGxcXFhV7XCQQCiomJUSAQ0Ny5c7Vo0SJ169ZN8fHx+t73vqesrCzugAMAhLEKoBdeeEGSNG7cuLD9q1at0pw5cyRJv/zlLxUREaGZM2eqpqZGkydP1q9//esmmSwAoP3wGWOM60l8VXl5uQKBgIYMGaLIyMjrrvvtb39rfawzZ85Y10hS586drWu6d+9uXeOlUeO5c+esa7w0T5SkDh3sX0L00nSxU6dO1jVeGphK3tYiIsL+Xh4v33aX3l16Pb76JnEbXpq5fvHFF9Y1Xl7/9fJ966WBqeStiamXY8XExFjXXO119cZ4aWKan59vNb6mpkbPP/+8gsHgNZsd0wsOAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAATnj6RNSW8OGHH1qNX7dunfUx/u7v/s66RpKKi4utaz799FPrmurqausaL12gvXbD9tLBNzo62rrGpiv6l2pqaqxrJKm+vt66xktn66qqKuuakydPWtd4bXbvZR28dEdvqXO8trbWukby1pHeS42XDtpeOnVLuuyDRK9HaWmp1fjrXW+ugAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACZ/x2q2wmZSXlysQCLTIsXJycjzVPfHEE9Y1iYmJ1jVnzpyxrvHSCNFL40nJW5NQL81IvTS59DI3SfL5fNY1Xr6FvDSA9VLjZb29HsvL2nnh5Ti2zTS/Di9r3tDQYF2TnJxsXSNJBw8etK657777PB0rGAwqPj7+qs9zBQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAATrTaZqQ+n8+q6aCXZn4tafz48dY1eXl51jVemp56bf4aEWH//y9emoR6aUbqtcGqF6dOnbKu8fJt9/nnn1vXeP2+OHfunHWN1wawtrysXV1dnadjVVVVWdd4+b7YvHmzdc3HH39sXSNJO3fu9FTnBc1IAQCtEgEEAHCCAAIAOEEAAQCcIIAAAE4QQAAAJwggAIATBBAAwAkCCADgBAEEAHCCAAIAOEEAAQCcaLXNSNFyBg4c6KkuISHBuqasrMy6pmfPntY1R48eta6RvDWtPHLkiKdjAe0dzUgBAK0SAQQAcMIqgPLy8jRixAjFxcUpMTFR06dP16FDh8LGjBs3LvRZPl9ujz32WJNOGgDQ9lkFUEFBgXJzc7V7925t3rxZdXV1mjRpkiorK8PGPfLIIzp58mRoW7p0aZNOGgDQ9ll91OSmTZvCHq9evVqJiYnat2+fxowZE9rfqVMnJScnN80MAQDt0td6DSgYDEqSunXrFrY/Pz9fCQkJGjx4sBYvXnzNj7WtqalReXl52AYAaP+sroC+qqGhQQsWLNCoUaM0ePDg0P4HH3xQvXv3Vmpqqg4ePKgf/vCHOnTokNatW3fFr5OXl6enn37a6zQAAG2U5/cBzZs3T2+//bbefffda75PY9u2bZo4caIKCwvVt2/fy56vqalRTU1N6HF5ebnS0tK8TAke8T6g/8f7gICm09j7gDxdAc2fP19vvvmmduzY0egPh8zMTEm6agD5/X75/X4v0wAAtGFWAWSM0fe+9z2tX79e27dvV0ZGRqM1Bw4ckCSlpKR4miAAoH2yCqDc3Fy98sor2rhxo+Li4lRSUiJJCgQCiomJ0ZEjR/TKK6/o7rvvVvfu3XXw4EEtXLhQY8aM0dChQ5vlLwAAaJusAuiFF16QdPHNpl+1atUqzZkzR9HR0dqyZYuWLVumyspKpaWlaebMmfrRj37UZBMGALQP1r+Cu5a0tDQVFBR8rQkBAG4MdMMGADQLumEDAFolAggA4AQBBABwggACADhBAAEAnCCAAABOEEAAACcIIACAEwQQAMAJAggA4AQBBABwggACADhBAAEAnCCAAABOEEAAACcIIACAEwQQAMAJAggA4AQBBABwggACADhBAAEAnCCAAABOEEAAACcIIACAE60ugIwxrqcAAGgCjf08b3UBVFFR4XoKAIAm0NjPc59pZZccDQ0NKi4uVlxcnHw+X9hz5eXlSktL0/HjxxUfH+9ohu6xDhexDhexDhexDhe1hnUwxqiiokKpqamKiLj6dU6HFpzTdYmIiFDPnj2vOSY+Pv6GPsG+xDpcxDpcxDpcxDpc5HodAoFAo2Na3a/gAAA3BgIIAOBEmwogv9+vJUuWyO/3u56KU6zDRazDRazDRazDRW1pHVrdTQgAgBtDm7oCAgC0HwQQAMAJAggA4AQBBABwggACADjRZgJoxYoVSk9PV8eOHZWZmak9e/a4nlKL+8lPfiKfzxe2DRw40PW0mt2OHTs0depUpaamyufzacOGDWHPG2P01FNPKSUlRTExMcrOztbhw4fdTLYZNbYOc+bMuez8mDJlipvJNpO8vDyNGDFCcXFxSkxM1PTp03Xo0KGwMdXV1crNzVX37t0VGxurmTNnqrS01NGMm8f1rMO4ceMuOx8ee+wxRzO+sjYRQK+99poWLVqkJUuW6IMPPtCwYcM0efJknTp1yvXUWtzNN9+skydPhrZ3333X9ZSaXWVlpYYNG6YVK1Zc8fmlS5dq+fLlWrlypd5//3117txZkydPVnV1dQvPtHk1tg6SNGXKlLDz49VXX23BGTa/goIC5ebmavfu3dq8ebPq6uo0adIkVVZWhsYsXLhQb7zxhl5//XUVFBSouLhYM2bMcDjrpnc96yBJjzzySNj5sHTpUkczvgrTBowcOdLk5uaGHtfX15vU1FSTl5fncFYtb8mSJWbYsGGup+GUJLN+/frQ44aGBpOcnGyeffbZ0L6ysjLj9/vNq6++6mCGLePSdTDGmNmzZ5tp06Y5mY8rp06dMpJMQUGBMebiv31UVJR5/fXXQ2M+/vhjI8ns2rXL1TSb3aXrYIwxY8eONT/4wQ/cTeo6tPoroNraWu3bt0/Z2dmhfREREcrOztauXbsczsyNw4cPKzU1VX369NFDDz2kY8eOuZ6SU0VFRSopKQk7PwKBgDIzM2/I82P79u1KTEzUTTfdpHnz5uns2bOup9SsgsGgJKlbt26SpH379qmuri7sfBg4cKB69erVrs+HS9fhS/n5+UpISNDgwYO1ePFiVVVVuZjeVbW6btiXOnPmjOrr65WUlBS2PykpSZ988omjWbmRmZmp1atX66abbtLJkyf19NNPa/To0froo48UFxfnenpOlJSUSNIVz48vn7tRTJkyRTNmzFBGRoaOHDmif/zHf1ROTo527dqlyMhI19Nrcg0NDVqwYIFGjRqlwYMHS7p4PkRHR6tLly5hY9vz+XCldZCkBx98UL1791ZqaqoOHjyoH/7whzp06JDWrVvncLbhWn0A4f/l5OSE/jx06FBlZmaqd+/eWrt2rebOnetwZmgN7r///tCfhwwZoqFDh6pv377avn27Jk6c6HBmzSM3N1cfffTRDfE66LVcbR0effTR0J+HDBmilJQUTZw4UUeOHFHfvn1beppX1Op/BZeQkKDIyMjL7mIpLS1VcnKyo1m1Dl26dNGAAQNUWFjoeirOfHkOcH5crk+fPkpISGiX58f8+fP15ptv6p133gn7/LDk5GTV1taqrKwsbHx7PR+utg5XkpmZKUmt6nxo9QEUHR2t4cOHa+vWraF9DQ0N2rp1q7KyshzOzL1z587pyJEjSklJcT0VZzIyMpScnBx2fpSXl+v999+/4c+PEydO6OzZs+3q/DDGaP78+Vq/fr22bdumjIyMsOeHDx+uqKiosPPh0KFDOnbsWLs6Hxpbhys5cOCAJLWu88H1XRDXY82aNcbv95vVq1eb//mf/zGPPvqo6dKliykpKXE9tRb1+OOPm+3bt5uioiLz3nvvmezsbJOQkGBOnTrlemrNqqKiwuzfv9/s37/fSDLPPfec2b9/v/nss8+MMcb8/Oc/N126dDEbN240Bw8eNNOmTTMZGRnm/PnzjmfetK61DhUVFeaJJ54wu3btMkVFRWbLli3mr//6r03//v1NdXW166k3mXnz5plAIGC2b99uTp48GdqqqqpCYx577DHTq1cvs23bNrN3716TlZVlsrKyHM666TW2DoWFheaf//mfzd69e01RUZHZuHGj6dOnjxkzZozjmYdrEwFkjDG/+tWvTK9evUx0dLQZOXKk2b17t+sptbhZs2aZlJQUEx0dbb7xjW+YWbNmmcLCQtfTanbvvPOOkXTZNnv2bGPMxVuxf/zjH5ukpCTj9/vNxIkTzaFDh9xOuhlcax2qqqrMpEmTTI8ePUxUVJTp3bu3eeSRR9rd/6Rd6e8vyaxatSo05vz58+bv//7vTdeuXU2nTp3Mt771LXPy5El3k24Gja3DsWPHzJgxY0y3bt2M3+83/fr1M//wD/9ggsGg24lfgs8DAgA40epfAwIAtE8EEADACQIIAOAEAQQAcIIAAgA4QQABAJwggAAAThBAAAAnCCAAgBMEEADACQIIAODE/wHAY74t0JzoZwAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "still not satisfactory , but can determine we are in the right track . Lets seemore"
+      ],
+      "metadata": {
+        "id": "vj9aXbA9jmhC"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "torch.manual_seed(42)\n",
+        "fig = plt.figure(figsize=(9, 9))\n",
+        "rows, cols = 4, 4\n",
+        "\n",
+        "for i in range(1, rows * cols + 1):\n",
+        "    random_idx = torch.randint(0, len(train_data), size=[1]).item()\n",
+        "    img, label = train_data[random_idx]\n",
+        "    fig.add_subplot(rows, cols, i)\n",
+        "    plt.imshow(img.squeeze(), cmap=\"gray\")\n",
+        "    plt.title(class_names[label])\n",
+        "    plt.axis(False)\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 752
+        },
+        "id": "xlnDg27xjtbz",
+        "outputId": "cc1e9484-cd5e-4518-d44d-c0626a1f8d21"
+      },
+      "execution_count": 37,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 900x900 with 16 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAswAAALfCAYAAAB1k5QvAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAplVJREFUeJzs3Xd8VVW+//9PDCSEhIQWCAmQQOhFUECwIEUQFUQdUGHUAWyMimXGGb+WO1edUceKqFjn5ygiDpYBK6ioqCPoYAMFpfcaSuhNYf/+8EGuYb3XZh8SSHs9H4953MuHtc7eZ5+111ke9md94oIgCAwAAACAdExJnwAAAABQmrFgBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCVPgF89ChQy0lJeWQ7bp3727du3cvtuN2797d2rRpU2yvBxRVXFycjRgx4pDtnn/+eYuLi7OlS5ce+ZMCgHKOdUjZUCYXzE888YTFxcVZ586dS/pUyqR77rnHXn/99ZI+DRxF33//vQ0cONCys7OtSpUqlpWVZb1797bHHnvsiB+b8Yaj4cB/yP36f3Xq1LEePXrY5MmTS/r0UM6wDimasvi9UCYXzOPGjbOcnBybMWOGLVy4sKRPp8wpiwMVh2/69OnWsWNHmzVrll1xxRU2evRou/zyy+2YY46xRx55JObXu+SSS2zXrl2WnZ0dqT3jDUfTX//6Vxs7dqy98MILdtNNN9n69evtrLPOsrfffrukTw3lCOuQoimL3wuVSvoEYrVkyRKbPn26TZgwwYYPH27jxo2z22+/vaRPCyi17r77bktLS7Mvv/zSqlevXujv8vLyYn69+Ph4i4+PD20TBIHt3r3bkpKSYn59oCjOPPNM69ixY8GfL7vsMqtbt67961//sn79+pXgmaG8YB1SMZW5X5jHjRtnNWrUsL59+9rAgQNt3LhxTpulS5daXFycPfjgg/bMM89Ybm6uJSYmWqdOnezLL7885DFmzpxp6enp1r17d9u+fbu33Z49e+z222+3Jk2aWGJiojVo0MBuuukm27NnT+T38/XXX9tJJ51kSUlJ1qhRI3vqqaecNnl5eQWTfpUqVaxdu3Y2ZswYp92OHTvsxhtvtAYNGlhiYqI1b97cHnzwQQuCoKBNXFyc7dixw8aMGVPwz5ZDhw6NfL4oexYtWmStW7d2FstmZnXq1HFir7/+urVp08YSExOtdevW9u677xb6e/UMc05OjvXr18/ee+8969ixoyUlJdnTTz/NeEOJq169uiUlJVmlSv/3+9CDDz5oJ510ktWqVcuSkpKsQ4cO9tprrzl9d+3aZdddd53Vrl3bqlWrZv3797dVq1ZZXFyc3XHHHUfxXaA0YR1SQdchQRnTokWL4LLLLguCIAg+/fTTwMyCGTNmFGqzZMmSwMyC4447LmjSpElw3333Bffff39Qu3btoH79+sHevXsL2g4ZMiRITk4u+POMGTOCGjVqBL179w527txZEO/WrVvQrVu3gj/v27cvOP3004OqVasGN9xwQ/D0008HI0aMCCpVqhScc845h3wf3bp1CzIzM4M6deoEI0aMCB599NHglFNOCcwsePbZZwva7dy5M2jZsmVQuXLl4A9/+EPw6KOPBl27dg3MLBg1alRBu/379wc9e/YM4uLigssvvzwYPXp0cPbZZwdmFtxwww0F7caOHRskJiYGXbt2DcaOHRuMHTs2mD59+qEvPMqs008/PahWrVrw/fffh7Yzs6Bdu3ZBvXr1gr/97W/BqFGjgsaNGwdVq1YNNmzYUNDuueeeC8wsWLJkSUEsOzs7aNKkSVCjRo3g5ptvDp566qlg6tSpjDccNQfG5QcffBCsX78+yMvLC2bPnh0MHz48OOaYY4L333+/oG39+vWDq6++Ohg9enQwcuTI4IQTTgjMLHj77bcLveYFF1wQmFlwySWXBI8//nhwwQUXBO3atQvMLLj99tuP8jtEacE6pGKuQ8rUgvmrr74KzCyYMmVKEAS/fDj169cPrr/++kLtDgzUWrVqBZs2bSqIv/HGG4GZBW+99VZB7NcD9bPPPgtSU1ODvn37Brt37y70mgcP1LFjxwbHHHNM8J///KdQu6eeeiows2DatGmh76Vbt26BmQUPPfRQQWzPnj1B+/btgzp16hTcTKNGjQrMLHjxxRcL2u3duzc48cQTg5SUlGDr1q1BEATB66+/HphZcNdddxU6zsCBA4O4uLhg4cKFBbHk5ORgyJAhoeeH8uP9998P4uPjg/j4+ODEE08MbrrppuC9994rNGEHwS8L5oSEhEJjZdasWYGZBY899lhBzLdgNrPg3XffdY7PeMPRcGBcHvy/xMTE4Pnnny/U9teLkCD4ZU5t06ZN0LNnz4LY119/7XzRB0EQDB06lAVzBcY65BcVcR1Sph7JGDdunNWtW9d69OhhZr/8rH/hhRfa+PHjbd++fU77Cy+80GrUqFHw565du5qZ2eLFi522U6dOtT59+thpp51mEyZMsMTExNBzefXVV61ly5bWokUL27BhQ8H/evbsWfB6h1KpUiUbPnx4wZ8TEhJs+PDhlpeXZ19//bWZmU2aNMkyMjJs8ODBBe0qV65s1113nW3fvt0++eSTgnbx8fF23XXXFTrGjTfeaEEQkCVegfXu3ds+//xz69+/v82aNcvuv/9+69Onj2VlZdmbb75ZqG2vXr0sNze34M/HHnuspaamynvmYI0aNbI+ffoU+/kDsXj88cdtypQpNmXKFHvxxRetR48edvnll9uECRMK2vz62fr8/HzbsmWLde3a1b755puC+IFHka6++upCr3/ttdce4XeA0ox1yC8q4jqkzCyY9+3bZ+PHj7cePXrYkiVLbOHChbZw4ULr3LmzrVu3zj788EOnT8OGDQv9+cCgzc/PLxTfvXu39e3b14477jh75ZVXLCEh4ZDns2DBApszZ46lp6cX+l+zZs3MLFoyVWZmpiUnJxeKHeh/4PnQZcuWWdOmTe2YYwp/VC1btiz4+wP/NzMz06pVqxbaDhVTp06dbMKECZafn28zZsywW265xbZt22YDBw60H374oaDdwfeM2S/3zcH3jNKoUaNiPWfgcJxwwgnWq1cv69Wrl1100UX2zjvvWKtWrWzEiBG2d+9eMzN7++23rUuXLlalShWrWbOmpaen25NPPmlbtmwpeJ1ly5bZMccc44zrJk2aHNX3g9KDdUjFXoeUmV0yPvroI1uzZo2NHz/exo8f7/z9uHHj7PTTTy8U82XyB796+NzMLDEx0c466yx744037N13342USb1//35r27atjRw5Uv59gwYNDvkawNGWkJBgnTp1sk6dOlmzZs1s2LBh9uqrrxZkeEe9ZxR2xEBpdMwxx1iPHj3skUcesQULFtimTZusf//+duqpp9oTTzxh9erVs8qVK9tzzz1nL730UkmfLkox1iEVW5lZMI8bN87q1Kljjz/+uPN3EyZMsIkTJ9pTTz11WF/acXFxNm7cODvnnHPs/PPPt8mTJx+ymk5ubq7NmjXLTjvtNIuLi4v5mGZmq1evth07dhT6r7v58+eb2S+7DpiZZWdn23fffWf79+8v9F93c+fOLfj7A//3gw8+sG3bthX6r7uD2x14v8CBrbfWrFlzRI/DeENJ+/nnn83MbPv27fbvf//bqlSpYu+9916hf/J+7rnnCvXJzs62/fv325IlS6xp06YFcfbcrbhYh1TsdUiZeCRj165dNmHCBOvXr58NHDjQ+d+IESNs27ZtzvOYsUhISLAJEyZYp06d7Oyzz7YZM2aEtr/gggts1apV9o9//EOe744dOw55zJ9//tmefvrpgj/v3bvXnn76aUtPT7cOHTqYmdlZZ51la9eutZdffrlQv8cee8xSUlKsW7duBe327dtno0ePLnSMhx9+2OLi4uzMM88siCUnJ9vmzZsPeX4oH6ZOnSp/IZ40aZKZmTVv3vyIHp/xhpL0008/2fvvv28JCQnWsmVLi4+Pt7i4uELPmy5dutQponDgefwnnniiUPxoVMdE6cM6hHVImfiF+c0337Rt27ZZ//795d936dLF0tPTbdy4cXbhhRce9nGSkpLs7bfftp49e9qZZ55pn3zyibfO+iWXXGKvvPKK/f73v7epU6faySefbPv27bO5c+faK6+8UrAfbZjMzEy77777bOnSpdasWTN7+eWXbebMmfbMM89Y5cqVzczsyiuvtKefftqGDh1qX3/9teXk5Nhrr71m06ZNs1GjRhX8V9zZZ59tPXr0sNtuu82WLl1q7dq1s/fff9/eeOMNu+GGGwolcnXo0ME++OADGzlypGVmZlqjRo0o71mOXXvttbZz504777zzrEWLFrZ3716bPn26vfzyy5aTk2PDhg07osdnvOFomjx5csEvWnl5efbSSy/ZggUL7Oabb7bU1FTr27evjRw50s444wz77W9/a3l5efb4449bkyZN7Lvvvit4nQ4dOtiAAQNs1KhRtnHjRuvSpYt98sknBb++lcVfyHD4WIewDikT28qdffbZQZUqVYIdO3Z42wwdOjSoXLlysGHDhoLtXB544AGnnR20HdDB+x8GQRBs2LAhaNWqVZCRkREsWLAgCAJ3O5cg+GVblfvuuy9o3bp1kJiYGNSoUSPo0KFDcOeddwZbtmwJfU/dunULWrduHXz11VfBiSeeGFSpUiXIzs4ORo8e7bRdt25dMGzYsKB27dpBQkJC0LZt2+C5555z2m3bti34wx/+EGRmZgaVK1cOmjZtGjzwwAPB/v37C7WbO3ducOqppwZJSUmBmZW5rV0Qm8mTJweXXnpp0KJFiyAlJSVISEgImjRpElx77bXBunXrCtqZWXDNNdc4/bOzswuNEd+2cn379pXHZ7zhaFDbylWpUiVo37598OSTTxaaB5999tmgadOmQWJiYtCiRYvgueeeC26//fbg4K/EHTt2BNdcc01Qs2bNICUlJTj33HODefPmBWYW3HvvvUf7LaIEsQ5hHRIXBBGyeQAAgM2cOdOOO+44e/HFF+2iiy4q6dMBcJSUiWeYAQA42nbt2uXERo0aZcccc4ydeuqpJXBGAEpKmXiGGQCAo+3++++3r7/+2nr06GGVKlWyyZMn2+TJk+3KK69kyy6gguGRDAAAhClTptidd95pP/zwg23fvt0aNmxol1xyid12221WqRK/NwEVCQtmAAAAIATPMAMAAAAhWDADAAAAIVgwAwAAACEiZy1Q1QhHSkk+Rl8exrV6D+qaJicny/6DBg1yYtu3b3di+fn5sn9GRoYT27Ztm2w7ceJEGS+PGNcojxjXKI+ijGt+YQYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCUKoIKIWiJvKFxQ/Wt29fGa9Ro4YTq1y5shNTyX1mZm3btnViLVu2lG2PZtJfLNcQAIAw/MIMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhGDBDAAAAISICyKmjVOSUmvevLkTS09Pl2137drlxNRuBGZme/fujdR23759sv/+/fsjxXzHOuYY97+lVMxMj41q1arJtt9++60TU2WYj5byMK5TU1Od2IABA5xYx44dZf/p06c7sf/3//6fE1O7YZiZrV692on97W9/k21Vee5ly5Y5sSlTpsj+W7ZskfHSiBLCKI8Y1+WP77qWxl2FMjMzZVzt4uRb88ycOdOJURobAAAAKCIWzAAAAEAIFswAAABACBbMAAAAQAiS/gRfcpt6gPzuu+92YvXq1ZP99+zZ48R8JYRVgl/VqlWdmErYM9Pljn12797txCpVcqumr1y5UvZXQ8j3sP2jjz7qxCZNmnSoUzxiSuu4PvbYY53YcccdJ9uqz/rnn392Yg0bNpT91VhT1yU3N1f2f//9953YggULZNsmTZpEOr4vaXT9+vVOzJcguHDhQhk/WkoyYUbNYbGcTyz3RWlMDMKRQ9Jf0aj3UNR7U8V838Hq+6JRo0ay7bx585zYjh07DnWKobKzs2W8bt26TkwlifukpaU5MZUQb2b22muvObEo74tfmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQLJgBAACAEO5WCIgpY1XtfKF2nTDTpbHnz58v21apUsWJxcfHO7FNmzbJ/rVq1XJivt0/EhISIh3Ld11++uknJ5aYmCjbLlq0SMYrqgsuuEDGW7Vq5cSWLFki2+bn5zsxNS7U52Sms4tVhvWHH34o+6sdOWrXri3bqjLo6rxUuW0zs+rVqzuxIUOGyLb//ve/nZgqiVrRqXt93759kfursarGhI9vpx91DmpHFd+8pt6X2v2nOHZeUHOjivnONZbrpe7NpKSkyK+p2s6dO1e2VfcrSlZRdylp3ry5E0tPT5dtd+7c6cR8Y0UZMGBA5LZqFzA1htV3gJkeq2ptY+Zfox0KvzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIUj6KyKVsOJLmFEPoPseSleJKKptVlaW7K8SQ1TCi5lOjlHJKb5Sm6qtSs4xO/yH7cuDjIwMJ+YrjT5nzhwn5ktOUp+fSuzxXXuVNKiSRrdu3Sr7q4QRX8KRujfUeflKY6u2ixcvlm3bt2/vxCpK0l8siUGxJPidfvrpTqxv375ObOnSpbL/hg0bnFjbtm1lW5XEoxKnfXOoSshW95AvES+WZMCor+u71lET+cx0aWN1vdW1MtPl6adNmybbvv766zKOw3ckSour1/SNXzU3+5L0U1JSnFidOnWc2GWXXSb7q7m5Zs2asq1an6h7WyUimun7xXe/He5nwC/MAAAAQAgWzAAAAEAIFswAAABACBbMAAAAQAiS/opIJSGpJCwzncjkewBeJc2pB9V9VbJiSThR56te13csda6ZmZmyre+B/YqgRYsWTmzz5s2ybSzV87Zs2eLEYhkr6vNT5+WrsKTGlS/BVCU3qaqWvkSsbdu2OTFfgqA6X5UIcySScMq6e+65R8ZVIp1KzlNVFs305++bE0488UQnpqpCxjLfqrHquy/UufoSn5Wo86qZTm5S19rMbN68eU5MXW9f4u3VV1/txLp16ybbfvTRRzKO0s83B6uk0R07dsi26h5SSX8rV66U/VUVWd+x1L2hNjXw9Vf3tm9uOFz8wgwAAACEYMEMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhGCXjCJKTk52Yr4ykyqLU2X9m+lMVpXh7yt/qrKufRmjKptatfVlbatdFnyZrKo0bkXhKxeuxJJhX7VqVSemxoWvNLYar2o3Al8JYrVzgG+sKOq6+Ma1ui6+XRZUhrbaaWT9+vWHOsUyR11T9ZmamX3wwQdO7PHHH5dt1Y4mAwYMcGJXXXWV7F+vXj0ntnr1atlWjaEzzzzTiaky8mZ6XKvdV3w7X6j5uqildlWpYTO9o4GvvHh2drYT69q1a+RzUu/Bd283bdpUxlFyou70o3aYMDNr1KiRE/PNgeo7Iz093Ylt2rRJ9s/IyHBivrWBmps3btzoxHxjVd3bvu883w4ih8IvzAAAAEAIFswAAABACBbMAAAAQAgWzAAAAEAIkv6KSJWO9CWRqAfzVVlZM53IpB6K9yUYpqamOjFfqVQVVw/L+5LOVDKR72H7ikwl/KxZs0a2VYkZy5Ytk21VIpxKgPAlOkRN0PMlhtSqVSvS8X1xlUjmS4ZVbVXirZkeryphqjwm/al7snv37rJt3bp1ndjEiRNl25dfftmJqXGVm5sr+6vPKicnR7YdOXKkE1Pz2sknnyz7qxLSam72JfKpuVUlXJnpca3ea35+vuz/448/OjFfkmarVq2cmEqEimW+V4nDYeeA0s+XYKqSoX1zoLoHfAnZilof+ZIRo87DvmTWWBLV1aYKUfALMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCCBTMAAAAQgl0yhKhlTs10hrWvBLXK8PdlaCvqdX1ZzCquMlbNdOb55s2bnZhvNwK1I4bvWBWZ2k1i0aJFsm27du2cmC+LWO0ooUoj+zL8FTXWVHa1r61v5w2Vja92SfjPf/4j+x977LGRj6XGsCrNXFEMGzZMxq+99trIr9GwYUMntnbt2sj91VitXr26bHvZZZc5sb/97W9OzLcjT4sWLZyYmoN91Bzqu4eWL1/uxNatW+fEtm7dKvur3TN8u4eoMbxgwQIn5ttBSX2/NWvWTLb1lZ1HyYlaGtu3Q4S6X3xzu5pD1ZqlcePGsr8qje27X2vWrOnE1PjzldZW1Peg2eHv/sIvzAAAAEAIFswAAABACBbMAAAAQAgWzAAAAECICp/0F/UBeh+VgOFL+tuyZYsT85WbVol4n332mRPzlTtWx/Ilkah4UlKSE9uwYYPsn5mZ6cS+/fZb2bYiUwlvviQgVRpblc8185dij0r1V2M4ltLavrYq4WPmzJlOzFfWNS8vz4n57jeV9OJLXC1vVOnX/v37y7ZDhgyJ/LpqXlDzpe/zV5/V0qVLZdsOHTo4scGDBzuxWbNmyf4fffSREzvhhBOc2OLFi2V/Nbdv3LhRtj377LOd2LRp05yYbw5WiVTqvZqZffjhh05MjWtfgqK631Vyl5l+XygbfMl1K1eudGLZ2dmyrUroVfPq9u3bZX+V/K/mEDOzuXPnOjGVuOrbKEHFY2kbBb8wAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACFI+iti0p9K2vJV2FEJfr5jqaSnVq1aRT6vVatWObGff/5ZtlXVt1SCmko6NDPr16+fE/vmm28OdYrlmqqcdMwx7n+f+pKjVGKEL1FBvW4sVf1Uf3UsXxKJb7wrqvJSLMka6h5KT0+XbVUiky/hpLz53e9+58QmT54cub9v/Piqx0Wl5js1/sx0FczTTjvNifkqDarKmqpS4ddffy37v/DCC07MlyCpklHVWF22bJnsf/nllzsxlQxrFr1aoW9uUdXTfPdbmzZtIh0LR0/U9cmKFStkXCX4+ZI+VfK5Ss7zJV5Pnz7difmS1NX6RM3XvsRtVb3P9910uN8D/MIMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhGDBDAAAAIQolbtkFHXniiNFndeuXbucmCoHaabL1foyPlXGqCqX7csCrVu3buRjKSprtnPnzpH7L1iwIHLb8kiV1VVjRWX2munP2kdlHavx49slJeouG74y3nXq1Il0Tr5jqWx+37mq1/Xt3KDKtVavXl22LW9UdvuYMWMi9/fNtypDXu2w4MuaV3y7PkQt4XzFFVfI/lOmTHFi8+fPd2K++frWW291Yr45VI21Pn36ODFVmtvM7PPPP3diquS8WfRdaXz3oNqpRu2cYaZ3+kDRRF3f+Haqidrfdw+qHbh8x1LfT2q+VWsbMz3WfPLz851YzZo1nVhWVpbsv3DhQie2Y8cO2da3s9Kh8AszAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEKJUJv0dzQS/WEoIq+QU9QC9KittFr0ssJlOjlLH8pUrVkkcvgfglQYNGkQ6vo8viaSiUIkR6rP2JbepZAuVyGmmSwirxCBfqVyVXKTui8zMTNlfJTz57gGViKTGui9hSSXtZWRkyLbfffedE1Ofiy8xxZeQWRaoRMx58+ZF7u9LGIplvlRiSW5SY0Aloa1cuVL2P+WUU5yYKonrS2b98ccfnZivVLS63hs2bHBiH3/8seyv7k3fZxD1foklacx3rNKQbF/eRL2mvnZR78HGjRvLuJrv09LSZFuVqK6+s3znFEtCsErEU+/BV15+48aNkV7TzP+9eyj8wgwAAACEYMEMAAAAhGDBDAAAAIRgwQwAAACEKJVJf0dTLEkNTZs2dWLqAXZfcp16MN5XtUkldhS16lIsSQTLly93Yr7kKHUNVKW7ikRVBFMJEL5rumbNGiemEpbMoo9hXyKd+vzU+Iul8pjvWIo6f1+CokrE8yW+qmsbS8KLStoqK9T1Uwk8Pr4ETzVWYpmXYkn6U23V56/GqplZXl6eE4s61s30fO9LEFSJSOq+8N3vsSRTqoQl9R5ime999yuV/opfUSsZq89Kjav69evL/tu2bXNivuQ4VWlPVfH1JUirc/WtDVTy9g8//ODEfEm+KvHWV9l1yZIlMn4o/MIMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhGDBDAAAAISoULtkxFKCV+ndu7cTUxmn1apVk/1VhnYs2ckqE9VXgliVsVZlgX2vobLsfbsRqF1B2rdvL9u+9dZbMl7eRN05wveZqEx4Xxl1Na5iKX+rzkvFfJ+/2hHEV3pU3YNRY2Z6lwtfhrk6L3VdVMn7sk59VrHsxODbkUVR1784dmhQc5AaV75xrcSyG4HaVSSWnYLUWPXtiqTme9/npY6l5oZYdh/xXRd2yYgmlp0vot6HsfQ/4YQTnJhvVyO1NvB9t8yePTvS6/p2FGrdurUT833nffvttzJ+sCZNmsi4mvM2b94s2x7uuOYXZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACDEEUn6iyW5JJYkjKh8ZXV9D7Yf7LzzzpNxVWZRvaYvsUMljPjOKWrSni9hScV9SQAqkUY9QL9z507ZXyVo+UpSVhTqHoglkU+19SWTqrYqQdSXsBQ1GdaXCKb6x5LcpJKYfIlc6nr5rqG6B9S18iWhlGUqGdlXvlaJZazEUvK9qMlpUcud+15XjQlfyfCopbnN9P0SdQ4w09fFlwwZS5Ksos4hlsRLuIpa2lrxfabNmjVzYmq+3bhxo+yfk5PjxHzJcWoebtSokRPzleFW/RctWhS5rXpf+fn5sr+aG3xzeyyJwr/GL8wAAABACBbMAAAAQAgWzAAAAEAIFswAAABACBbMAAAAQIjIKbCxlH5UcV/GZ9TsXt+xVMapLxNZ6dGjhxM79thjZduVK1c6MVUCukaNGrK/2mXCt/OByuZWGdq+7FaVSeq7hqo0tso49Z2rGhs1a9aUbSuKqJ+fL1tX3Re+ca2OFbXctS+usuN956rGtS87WY0VdV182fmqv2+XhczMTCe2fft2J3a4GdOlmZqrrrzyStn273//uxPzjbWoGf6+nUvUuPZ9flF3johlhwj1+ccyB/usW7fOicWyc4Jq67su6hqoa+W7h9T9Fst3ZkmKZR0Stb/PkdjBy8wsNTXViam5Su1mYabPa8eOHU6sefPmsr/6ble76pjpXY3UWPPNoep11T1opj8bdSy1g5iZ2aZNm5zYmjVrZNuo89jB+IUZAAAACMGCGQAAAAjBghkAAAAIwYIZAAAACHFEkv6Uw33I+nD4Svj269fPiTVp0sSJqYfHzcxq167txNTD9rFcl61bt8q4KmuprmEsiZe+xA71YH+DBg2cWCzJOSqJoSKJmojnS8yJZQyp8qGqtLnvNVXSlEraW7t2reyvkkh8pbFVPJZyyWqs+u4hNQZVguLRnJuOlu+++86JPfXUU7KtSvrzXdPs7GwnNnv2bCfmSwKKWho9LH4w37hWyW116tRxYr7S2Hl5eU5Mnb+ZWUZGhhNTCdm+5KpYktGi8iVeqlLivmvoKztemsRSWr2oiXy+BNPk5GQn1rhxY9m2evXqTkyNC1/Cmuqvvm/U2sQsts9fzY1169Z1Yr7vBrVmUveKWfQk28WLF8u4er+vvPKKbJubmxvpWAfjF2YAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgROSkP/Xwd61atWTbli1bugeKoeqQeohfJRaZ6QfQ1YPmvtdQD6urxBAznTQ3d+5cJ6YS9szM6tWrF+k1zXTioor5khBiqeakXkMlPvo+A5XIpY5fkahrre4BVWXRzGzFihVOTCWsmUWvKhhLwovq76uIppKLfMlCvgqAUamx6ksWiZoI4/sMyrJ33nnHiX3//fey7UknneTEpk+fLtuqMazmBd9YU3O77/MravU51V99Z1100UWy/8yZMyMf63/+53+cWJ8+fZyYSiQ009fQl7Tnm4ejUsmUKknYzJ/8WVKKWtVPJcyZ6cq06enpTsw3f0VNnDbT83j9+vWdmC8Zdf369U4sLS3NiW3ZskX2V4mr6jXNzDp16uTE1PeAb82lvgd8awM1BtU6JJaq0b575XDnFn5hBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCRN4lQ2natKmMq/Kpvkz0ou4GsWHDBifmyy7dvn27E1OZtKqdWfQMcVUS1Uxnh/oyadXuH7Gcq8qEVbt0mJmlpqY6sdWrVzsx32eoMmGLmsld1qlsbnWdUlJSZH+1o4FvVxqVIa3GoG+nGjWu1K44vs80agljM30PqHs7ltLYvjLc6j2oXTIqyli96aabZPwPf/iDE/PtkvH22287sWOPPdaJqex2M70jhi9jvajloqPuXKB2pDHT94vvXNVuEupYvp0v1HWJ5X5V96DvXNXc5Pt+/c9//iPjpUmNGjVkXM2tvrlKfS7Lly93Yr7S6IrvmqpzUN+tvvGv5ju15vHtcKLWAV26dJFt1VosKyvLiak1hJnZkiVLnJhvtyc1X6tr5Sutrb4zP//8c9nWt3Y9FH5hBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEJETvpT5aK7du0q265bt86J+R5gV0k427Ztc2LJycmyvyp16Uuki1ou2JeIpRID1MPuvlKvKmHAl0SgHoz3Jfgp6hxiSY5QiQUqAcB3XioxwMxfQrO8UeNKJTX4PpNPPvnEiXXo0EG2VcmAURMofG3VvaLa+fgSllQijDov33yh2qrkHDOzJk2aODH1Hoparrs0Utdv9uzZsq1KEH3zzTdlWzUHquvnu89VIpovOUp9Vur4sZSQXrZsmRM7/fTTZf8ff/zRifkS6dT30+LFi52Yb6yp9+q7hxR1v/qSWVXSlEqeNzP77LPPIp9DSWnVqpWMZ2ZmOjFfWWaVNKe+A33f12od42urxooaw77vWzUu1Pe9772q7wvfuaqS3eq85syZI/ur8tyqtLaZTl5X36O+99WwYUMn9vjjj8u2vqTmQ+EXZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgROQ03M6dOzuxfv36ybY//PCDE/OVaVTZmWqXjVWrVsn+KovTt5uEyq5UO0SozEwznTWrspvVLh9mOjtWnb+ZzhiNJbtV8ZUQVpnfavcG3y4J6nV9metqt5XySF0Tlcns2w1i48aNTsy3y4XaZcCXYa2o+0Kdq+8z9WUtK2qXANVflRE30+PSl6F94oknOjE1hnfv3i37l2Uqk973Of33v/91YieccIJsu3TpUiemPivfLhnq8/fNYWpcq5hvXlP3lpqbR4wYIfurbH61m4KZ3iVBxXwlhH07hShqHlD9fSWIP/30Uyd25513Rj5+aeObF9Wawzcvqnkhll2p6tat68R833X5+flOTL0H333RsWNHJ6ZKa69evVr2V/eg2lHETM/58+fPd2K+HV3U9fa9L3Vvqtf13SvqXNXOGb7zioJfmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQkZP+3nrrLSfmS7Y499xznVizZs1kW5VwppJw1q5dK/urB8V9D+urRCpVPtRXhlvFVWlulQBgpkuS+pIh1TUYO3asE7vgggtkf5XM6Cvr6ivlfTBfMqRKWFBJCGb6epVHaqype8CXAKH6+5Id1BhWCRC++1W9rnpNX8n4NWvWODFf+VNFjR9fIo9KWPGVfFaJwiqZdsGCBYc6xTLHd68qaqypss4+ar71ff5qDPnaqnGpPn91/mZ6DKn7Ytq0abK/mi99Cd2+8XowNf7MdDKhL0lT3W+qjPf3338v+/u+cxRfUnJJUfNSVlaWbKu+a9avXy/bZmdnOzGVYOz7nGMpAa2+G6N+B/uo0uY1a9aUbdVY862vVDJky5YtnZhvTKn7JZaS32oe831nqrHq+7x8CeyHwi/MAAAAQAgWzAAAAEAIFswAAABACBbMAAAAQIjISX/Kv//978jxFi1ayLaDBw92Yo0bN3ZiTZs2lf3VA/S+B71VEoV6UNyX6KDimzdvdmK+ymN/+ctfnJgv4SSqhx9+WMbVefmSIaMmx/gq/anr6kswbNCggYyXN1EryvmSiBRf0p9K5oslkU5RSSi+pEH1+fuSzqLeb773quK+Sn0qiUQdS803ZrpiaVnhu/+UDz/80Il99NFHsq1KjlLjwlfRTiVO+xKE1XhVn18s73XFihVOzJc0Wl7FUlXQN+eXlObNmzsxX/XF5cuXOzHfd7v6vlRjxTcHKr55ybepwMFUgqOZTrBT78tXLVV9pr77Vd1b6jvcl8gXSyVidb+raxjLd0ssa8Eo+IUZAAAACMGCGQAAAAjBghkAAAAIwYIZAAAACMGCGQAAAAhRpF0yfFmcKgNx7ty5su3tt98e6Vi+7FaVNVuvXj3Ztnbt2k5MZdL7ykSuXr3aic2bN0+2PVp+//vfy/i6deucmCqfaaazZlWGrS8bWWXC+kpl5uXlObHx48fLtmWZ2hVGlXD1lfVVZs6cKePt27d3Ympc+zKW1eevsot9/dWOGr7sZPUaKmu/Vq1asr/KZvdR55CZmVmk16wofJnoS5cuPbongmJX2na+iIX6/hgwYIBsq+ZA384RajeIWHaKUnOYr616XbX7hm/3GLUjhWqrysj7+M5Vzdc7d+50Yr5dJ2K5hjt27HBi6j0UR7lr3/x2KPzCDAAAAIRgwQwAAACEYMEMAAAAhGDBDAAAAISICyI+/exLugOK6nAfwC8OR2pcqySO6tWrOzFfAoQvQVPp3bu3EzvttNOc2KpVqyIfKyMjw4n5znXlypVOLCUlRbZVyTHVqlVzYiqxxMzshRdecGKxlF9Vn/eRGn/lcVwDpW1cq6RjM53gW6NGDdlWlYZWiWy+EtAq7ktCU5slqGP5Sr6r+W7btm1OzDdfq2vo28BBJU762haVul4q+TuW65Kfny/bzpgxw4lFGdf8wgwAAACEYMEMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhGCXDJS40pZ1XR6o7OI2bdrItjVr1nRiKmvctxuF2tHCl0mtssFVefm5c+fK/mUJ4xrlEeMa5RG7ZAAAAABFxIIZAAAACMGCGQAAAAjBghkAAAAIETnpDwAAAKiI+IUZAAAACMGCGQAAAAjBghkAAAAIwYIZAAAACMGCGQAAAAjBghkAAAAIwYIZAAAACMGCGUCxef755y0uLs6WLl0ac9+hQ4daTk5OsZ8TAMDFfB2bcr1gjouLi/S/jz/+uKRPFThs33//vQ0cONCys7OtSpUqlpWVZb1797bHHnuspE8NOCoWLVpkw4cPt8aNG1uVKlUsNTXVTj75ZHvkkUds165dR+SYL730ko0aNeqIvDbKL+brsqtSSZ/AkTR27NhCf37hhRdsypQpTrxly5ZH87SAYjN9+nTr0aOHNWzY0K644grLyMiwFStW2BdffGGPPPKIXXvttSV9isAR9c4779j5559viYmJ9rvf/c7atGlje/futc8++8z+/Oc/25w5c+yZZ54p9uO+9NJLNnv2bLvhhhuK/bVRPjFfl23lesF88cUXF/rzF198YVOmTHHiB9u5c6dVrVr1SJ7aEbFjxw5LTk4u6dPAUXT33XdbWlqaffnll1a9evVCf5eXl1cyJwUcJUuWLLFBgwZZdna2ffTRR1avXr2Cv7vmmmts4cKF9s4775TgGQL/h/m6bCvXj2RE0b17d2vTpo19/fXXduqpp1rVqlXt1ltvNbNfBvBll11mdevWtSpVqli7du1szJgxhfp//PHH8rGOpUuXWlxcnD3//PMFsbVr19qwYcOsfv36lpiYaPXq1bNzzjnHeX5o8uTJ1rVrV0tOTrZq1apZ3759bc6cOYXaDB061FJSUmzRokV21llnWbVq1eyiiy4qtuuCsmHRokXWunVrZ/I1M6tTp07B///cc89Zz549rU6dOpaYmGitWrWyJ5980umTk5Nj/fr1s88++8xOOOEEq1KlijVu3NheeOEFp+2cOXOsZ8+elpSUZPXr17e77rrL9u/f77R74403rG/fvpaZmWmJiYmWm5trf/vb32zfvn1Fe/Oo8O6//37bvn27Pfvss4UWywc0adLErr/+ejMz+/nnn+1vf/ub5ebmWmJiouXk5Nitt95qe/bsKdQnynjt3r27vfPOO7Zs2bKCR/sq2vOciB3zddlWrn9hjmrjxo125pln2qBBg+ziiy+2unXr2q5du6x79+62cOFCGzFihDVq1MheffVVGzp0qG3evLlgEo7FgAEDbM6cOXbttddaTk6O5eXl2ZQpU2z58uUFk+3YsWNtyJAh1qdPH7vvvvts586d9uSTT9opp5xi3377baFJ+eeff7Y+ffrYKaecYg8++GCZ/FUcRZOdnW2ff/65zZ4929q0aeNt9+STT1rr1q2tf//+VqlSJXvrrbfs6quvtv3799s111xTqO3ChQtt4MCBdtlll9mQIUPsn//8pw0dOtQ6dOhgrVu3NrNf/uOvR48e9vPPP9vNN99sycnJ9swzz1hSUpJz7Oeff95SUlLsj3/8o6WkpNhHH31k//u//2tbt261Bx54oHgvCCqUt956yxo3bmwnnXTSIdtefvnlNmbMGBs4cKDdeOON9t///tf+/ve/248//mgTJ04saBdlvN522222ZcsWW7lypT388MNmZpaSknJk3iTKDebrMi6oQK655prg4LfcrVu3wMyCp556qlB81KhRgZkFL774YkFs7969wYknnhikpKQEW7duDYIgCKZOnRqYWTB16tRC/ZcsWRKYWfDcc88FQRAE+fn5gZkFDzzwgPf8tm3bFlSvXj244oorCsXXrl0bpKWlFYoPGTIkMLPg5ptvjvz+Uf68//77QXx8fBAfHx+ceOKJwU033RS89957wd69ewu127lzp9O3T58+QePGjQvFsrOzAzMLPv3004JYXl5ekJiYGNx4440FsRtuuCEws+C///1voXZpaWmBmQVLliwJPfbw4cODqlWrBrt37y6IDRkyJMjOzo783lGxbdmyJTCz4Jxzzjlk25kzZwZmFlx++eWF4n/6058CMws++uijgljU8dq3b1/GK2LCfF22VfhHMszMEhMTbdiwYYVikyZNsoyMDBs8eHBBrHLlynbdddfZ9u3b7ZNPPonpGElJSZaQkGAff/yx5efnyzZTpkyxzZs32+DBg23Dhg0F/4uPj7fOnTvb1KlTnT5XXXVVTOeB8qV37972+eefW//+/W3WrFl2//33W58+fSwrK8vefPPNgna//iVhy5YttmHDBuvWrZstXrzYtmzZUug1W7VqZV27di34c3p6ujVv3twWL15cEJs0aZJ16dLFTjjhhELt1GNBvz72tm3bbMOGDda1a1fbuXOnzZ07t2gXABXW1q1bzcysWrVqh2w7adIkMzP74x//WCh+4403mpkVes6Z8Yojhfm6bGPBbGZZWVmWkJBQKLZs2TJr2rSpHXNM4Ut0YEeNZcuWxXSMxMREu++++2zy5MlWt25dO/XUU+3++++3tWvXFrRZsGCBmZn17NnT0tPTC/3v/fffd5ICKlWqZPXr14/pPFD+dOrUySZMmGD5+fk2Y8YMu+WWW2zbtm02cOBA++GHH8zMbNq0adarVy9LTk626tWrW3p6esGz+gdPwA0bNnSOUaNGjUL/oXfg/jhY8+bNndicOXPsvPPOs7S0NEtNTbX09PSCxNuDjw1ElZqaama/fKkfyrJly+yYY46xJk2aFIpnZGRY9erVC83njFccSczXZRfPMJvJ53iiiouLk3H1gPwNN9xgZ599tr3++uv23nvv2V/+8hf7+9//bh999JEdd9xxBQ/gjx071jIyMpz+lSoV/rgSExOdBT0qroSEBOvUqZN16tTJmjVrZsOGDbNXX33VLr74YjvttNOsRYsWNnLkSGvQoIElJCTYpEmT7OGHH3YSP+Lj4+XrB0EQ8zlt3rzZunXrZqmpqfbXv/7VcnNzrUqVKvbNN9/Y//t//08mnQBRpKamWmZmps2ePTtyH998fQDjFUcL83XZw4LZIzs727777jvbv39/oUXpgX+SyM7ONrNf/kvO7JeB9mu+X6Bzc3PtxhtvtBtvvNEWLFhg7du3t4ceeshefPFFy83NNbNfsmV79epV3G8JFUjHjh3NzGzNmjX21ltv2Z49e+zNN98s9GuEesQnquzs7IJ/Efm1efPmFfrzxx9/bBs3brQJEybYqaeeWhBfsmTJYR8bOKBfv372zDPP2Oeff24nnniit112drbt37/fFixYUGjf/XXr1tnmzZsL5vNYxuuhFt9AVMzXZQM/T3qcddZZtnbtWnv55ZcLYj///LM99thjlpKSYt26dTOzXwZifHy8ffrpp4X6P/HEE4X+vHPnTtu9e3ehWG5urlWrVq1gW6M+ffpYamqq3XPPPfbTTz8557R+/fpieW8oP6ZOnSp/STjwzGbz5s0LfoH4dbstW7bYc889d9jHPeuss+yLL76wGTNmFMTWr19v48aNK9ROHXvv3r3O/QEcjptuusmSk5Pt8ssvt3Xr1jl/v2jRInvkkUfsrLPOMjNzKvONHDnSzMz69u1rZrGN1+Tk5Ar/T9SIDfN12cYvzB5XXnmlPf300zZ06FD7+uuvLScnx1577TWbNm2ajRo1qiDRJC0tzc4//3x77LHHLC4uznJzc+3tt992njeeP3++nXbaaXbBBRdYq1atrFKlSjZx4kRbt26dDRo0yMx++SfGJ5980i655BI7/vjjbdCgQZaenm7Lly+3d955x04++WQbPXr0Ub8WKL2uvfZa27lzp5133nnWokUL27t3r02fPt1efvlly8nJsWHDhtm6dessISHBzj77bBs+fLht377d/vGPf1idOnVszZo1h3Xcm266ycaOHWtnnHGGXX/99QXbFB34l5kDTjrpJKtRo4YNGTLErrvuOouLi7OxY8ce1j8XAgfLzc21l156yS688EJr2bJloUp/06dPL9gK9Prrr7chQ4bYM888U/DPzjNmzLAxY8bYueeeaz169DCz2MZrhw4d7OWXX7Y//vGP1qlTJ0tJSbGzzz77aF8ClCHM12VcyWzOUTJ828q1bt1atl+3bl0wbNiwoHbt2kFCQkLQtm3bgm3ifm39+vXBgAEDgqpVqwY1atQIhg8fHsyePbvQtnIbNmwIrrnmmqBFixZBcnJykJaWFnTu3Dl45ZVXnNebOnVq0KdPnyAtLS2oUqVKkJubGwwdOjT46quvCtoMGTIkSE5OPvyLgXJh8uTJwaWXXhq0aNEiSElJCRISEoImTZoE1157bbBu3bqCdm+++WZw7LHHBlWqVAlycnKC++67L/jnP//pbCmUnZ0d9O3b1zlOt27dgm7duhWKfffdd0G3bt2CKlWqBFlZWcHf/va34Nlnn3Vec9q0aUGXLl2CpKSkIDMzs2ArJTtoO8aKuE0Risf8+fODK664IsjJyQkSEhKCatWqBSeffHLw2GOPFWyF9dNPPwV33nln0KhRo6By5cpBgwYNgltuuaXQVllBEH28bt++Pfjtb38bVK9ePTAzxi4Oifm6bIsLAv7TAQAAAPDhGWYAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgRORKf3FxcUfyPErMxo0bndiGDRtk2/379zuxlJQUJzZ//nzZv0aNGk6scuXKsu327dudWM2aNZ3YzJkzZf8LL7xQxkujktwKvLyOa5Q8xvXRceqpp8p4z549nVjVqlWdWJUqVWR/VfZ6+fLlsu2zzz7rxNT3RXnAuEZ5FGVc8wszAAAAEIIFMwAAABCCBTMAAAAQIi6I+EBSaX12SJ2X7y01b97cic2dO9eJrVy5UvaPj493YomJiU7M9+zamjVrIvX3xbdt2+bE9u7dK/t36NBBxksjnolDecS4dsUyXyurVq1yYmpeNtPz8DHHuL8RJScny/4qv8V3rPr16zuxU045xYlNmzZN9i9LGNcoj3iGGQAAACgiFswAAABACBbMAAAAQAgWzAAAAEAIFswAAABAiMiV/kqrWDJ2//nPfzqx1atXO7EVK1bI/ipDV1X6S0hIkP137tzpxHxZ12r3C/VefccCgOKmKpP+9NNPkfur+WrPnj2y7dChQ52Y2j1I7T5kpne/UMdatmyZ7K/mdl9VwCVLljixjz/+2In5KrsqakcPs/JbQRAo7fiFGQAAAAjBghkAAAAIwYIZAAAACMGCGQAAAAhR5pP+YnHSSSc5sYULFzqxmjVrRn5NX2KGohJefEkgP//8c6SYKskKAEeCSvCLpdy1L8FPyc7OdmJbtmxxYtWrV5f9q1Wr5sTS0tKcmO9cd+3a5cTUHOyLf//997JtVCT3AaULvzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACHK5S4ZHTp0kPGNGzc6MZXdrLK+zXQZa5WhvW/fPtnfF4/atlIl9+PyZYirsrA7duyIfHwAiMK3y4Si5qXHHntMtj377LOd2IoVK5xYZmam7J+UlOTEXnrpJSemdt4wMzv//POdmG8HpcWLFzsxVcb7k08+kf1vvfVWJzZt2jTZVollpxIAh4dfmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQ5TLp74QTTpBxVYZalWqtUaOG7K9KW6vkPF+57NTUVBlX1Ln6yrIqKuGEpD8ARaESn9Uc6EuOU4ls6enpsu2aNWucmJrD8vLyZH/1unPnznVi3333new/ePBgJ5afny/b7t6924mpOTwrK0v2f/PNN53YsGHDIrdVx9q7d6/sD+Dw8AszAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEKJcJv2dc845Mh61qt/WrVtlf1U5qmrVqpHPS1Xq279/v2yrqjT5kgkV33sAgMMVtVrpZZddJuNVqlRxYuvWrYt8fJXMrBLuzHSC3xlnnOHEunfvLvurOXjp0qWyrUq6UwmSvkS8TZs2ObErrrhCtlVJfyT4AUcevzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACHK5S4ZDRo0kPGffvrJicWy84TKhFZltFUmt5nZxo0bnZiv3LXaUUPt6OHLMI+ljDaOjljGmsrQV7Gj6fjjj5dxtVPMZ599Fvl11bj2UddA3Stm0e+BatWqyfi2bdsinxcKU2Wlzcx27drlxHw7b6jPT8USEhJkfzXfJycnO7GmTZvK/mpu9Y1V9T2g3pcq7e1rm5GRIdtG5ZtvfDszAQjHL8wAAABACBbMAAAAQAgWzAAAAEAIFswAAABAiHKZ9JeTkyPjW7ZscWIqYUkli5jpsq6qJOmoUaNk/5tvvtmJrVixQrZVySXqXL/66ivZH6XP0Uy2UePHlzSoEqEuvfRSJ+ZLQlq+fLkTa9u2rWz77LPPOrFYyvqqBD9fcl9WVpYTe/TRR53Y5s2bZf8FCxY4sddee022XbhwoYxXBLGMNVUu2pf050uQO5gvyXr79u2R2i5btkz2V+8hPT1dtlXnqpJGfQmKSlpamoyrUt4ff/xx5NcFipsvGbaoieoffvihExszZoxs+8ILLxTpWFHwCzMAAAAQggUzAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEKLM75IRdTcJM7O8vLxIr+nL7KxTp44Tu/rqq53Y008/LfurXTJiKeurMsznzJkj+6NkRd054EhlF8fSf+fOnU5M7QijSsObmW3atMmJ1apVS7Z95JFHnNhdd93lxFatWiX7q/uiRYsWkY9Vt25dJzZ+/HjZv2bNmk7s5JNPlm0r8i4ZzZs3d2JJSUmyrRqXvp0j1GuoOdC3+4za/UUdS411M7M9e/Y4Md+OLlu3bnVi6r36yrCrHT1899spp5zixNglA0dLLDsVKaeddpqMT5w40Ylt2LDBiakdnMzMJkyY4MTUfWWm55Eo+IUZAAAACMGCGQAAAAjBghkAAAAIwYIZAAAACFHmk/46dOgQua0qea0SRho1aiT7q8SKJ598MvLxYxE1Qez7778/IsdH0URNuitqcl9x6NmzpxPr37+/E1NJdGZmF1xwgRP79NNPZVuVMHL33Xc7MV8S08yZM53YddddJ9uqkt3qWM2aNZP9VWltX4JhRabKoPvKVatEOl/is6LmcN89pObLXbt2OTFfYpDiSxY65hj3tycVU+dvps/Vl8zYrVs3J6YSZ339gaJQCX6+xN3/+Z//cWKXX365bDtt2jQntmXLFifWu3dv2f++++5zYtdcc41sq+7NKPiFGQAAAAjBghkAAAAIwYIZAAAACMGCGQAAAAhR5pP+OnbsGLmtelh93759Tsz3AHufPn0iHcdXaVDxPXyukkB2797txD7//PPIx0I0vup7sbRViUyqSpiqkmZmVr16dSfmS0ZVSU8vv/yybKuoxAx1/kOGDJH9VbKFSpgz00lT69evd2InnHCC7N+5c2cnNmnSJNlWVXA799xznZjvflXXwNc2ljFT3nTq1MmJ+RLO1Hznm29VpTsV8yXSqQQ/9Zn6jq/uK/V9YRa9MqZvvo86X5j5k1RRvKImcvr47oGSTsaMWoXWRyV5jxkzRradPXu2E1u2bJlsqyp7qu/BZ599Vva/6aabZFyJpTLhr/ELMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCCBTMAAAAQoszvkpGTk+PEfFmoKsM5JSXFif3nP/+R/X1ZywfbuXNnpHZm/ux6Fa9du7YTmzt3buRjwaWus+8zUZnEvgx7taOJGqsnnnii7L9t27ZIr2lm1rp1ayfWpk0bJ9a4cWPZX72ve++914ldffXVsv8tt9zixHw7erRs2dKJqaznRYsWyf4ZGRlO7PTTT5dtVda12uUiPz9f9le7L/h2yahWrZqMVwT16tVzYr4sdDU316pVS7ZVZbTVWPUdS+3IonY58O18ofh2SVDnpe7XOnXqyP6bN292Yr7vMbWrTEUWyw41vt0g1FhR4+Jo7nARy1hTu6z4do+JZUeMN99804m1bdvWifnWITt27HBivu9MVfJ95MiRTiyW3TCKG78wAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACHKfNKfKsu6ceNG2VY9sK9Kmj7zzDNFPzFBJbHEkrCwffv24jwdeMSSFOFLxFNUssKcOXNk2y+//NKJqcQUM50Id/755zsxXxLJAw884MTS09Od2OLFi2X/vn37OrG3335btr3hhhucmEpGVCWwfefgS2ZU71clUyYmJsr+KpFPlVv2HauiyMzMdGK+BGl1ndasWSPbrlu3zompZFL1mZrpRCiVIKhKWJvpecA3X6vk8by8PCe2atUq2V/db773pcZl3bp1nZi6fuVRLPO1T9TETzXXmZkNGDDAiakxYWb20EMPObH//ve/TiyWBENfgp/yhz/8wYmp5DozXdpajeu0tDTZX62vfNflN7/5jRObOHGibFtUhztmKu4sDwAAAETAghkAAAAIwYIZAAAACMGCGQAAAAhR5pP+GjZs6MRUdRkzndyjEqaO1IPmW7ZsidxWJaysXbu2OE8HppN4fMkWKtnGl5hz3nnnObGsrCwn5hsTf//7351YjRo1ZNuPP/7YianEkv79+8v+6j2oJKQ//vGPsv9f/vIXJ9a9e3fZViXXrF692on5PgNV1VDdK77XaNKkiRPzJZ2NGTPGib3xxhuRj1VRqDnYl3jdtGlTJ+abb1UFxuOOO86JrVixQvZX97ZKOowl8dqXHKaSm1RFvq+++kr2v/32253Yd999J9uqSmmq2mJ5TPqLJblWtfVVhWzQoIETe+KJJ5yYStw303OYLyH8f//3f53YvHnznJgaE2Zm1atXd2IDBw50Ytddd53sr75zLrnkEtlWJQhmZ2c7Md/93qJFCyfmq247Y8YMGS9N+IUZAAAACMGCGQAAAAjBghkAAAAIwYIZAAAACMGCGQAAAAhR5nfJUOWia9asKduqXTJUduvOnTuLfmKCyppVGc9mOsP3xx9/LPZzquhi2d3AtyOGonZzUFnvvtLYagz6dtT45JNPIrX17QbQtm1bJ6ZKtd56662yf5cuXZyY77pGzdxXuw6Y6TLGvsx1db/fc889Tsy384Xiu4YVuTS22r1F7RBhpsvibtq0SbZV95sqD++79r7dU6JS5XN95emj9v/0009lWzWufDs6qHNQ883MmTMPcYZlj7qmvjLHscztaqefKVOmOLFHH31U9j/llFOcmCqXbWaWk5PjxNTuPcOHD5f91b21ZMkSJ/bMM8/I/itXrnRivjl06tSpTkztyHLSSSfJ/gsXLnRiixYtkm3btGnjxKpWrerETjvtNNm/fv36TkztfmJmNmzYMBk/lIo7ywMAAAARsGAGAAAAQrBgBgAAAEKwYAYAAABClPmkP/UAue9B7127djkxX2LFkaDKR/rOVSWBLF++vNjPqaJTiQaqfK+Z2YcffujEtm7dKtvOmjXLianEjvnz58v+48ePl3ElLS3NiXXo0MGJqfKrZjo5JTk52Yn5kg7ffPNNJ6YS7sx0GWVValXdq2Y6ydeX9PPll186sVgS/FQymS+RyHcOFUFSUlLktuqabtiwQbbNyMhwYqo0tS8RM2rZe18iXyyf/08//eTEVHKUaucTS8n39u3bO7Fx48ZFPlZZoe6z9PR02VbNYUuXLpVtP/vsMyd2+eWXO7HevXvL/h07dnRia9eulW1fe+01J6YS+VSCs5lOnK1WrZoTU99tZmZnnHFG5GN9++23kWK+RD5FJZSb6e9M9Z3VuXNn2V+dg0qGNDNr3rx52Cl68QszAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCizO+S8fnnnzuxrl27yrYqw9aXYX0kqGxe3y4dqjSwyo71Ue+rImfy+/Ts2dOJqYxnM7NBgwY5MV+Gv/r81C4Tf/7zn2X/O++804m1bNlStlXZ9KrUaVZWluy/ePFiJxa1JKqZWf/+/Z2YylA30+eqdhpRu2GYme3YsUPGlbp16zoxlSU/d+5c2X/VqlVOrEWLFrLtX//618jnVZZlZmY6MTXWffPq7t27nZhvrKgdVTZv3uzEfLtcHIn5zleGW5X3Vrt8+LLz1Q5KsbyvRo0aybblTW5urhMbMWKEbDtjxgwnVrNmTdlWfS75+flOzLfLyeTJk52Yb4cGtdOGmq/V/GWm7y21S4Zv5wr1vny7v6hdadRn4NsVSd0X6lqZ6bWQ2oHnP//5j+yvzrVZs2ayrW+3lEPhF2YAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgRJlP+lPlomMplepLrDgSVLnf1NTUyP337t1bnKcDM3v00Ucjtz399NOdmCpJa2Z23nnnOTGV8ORL+rz77rudmC+JpHbt2k5MJfj5Sls3btzYiV1//fVOTCWmmJlVrVrViSUkJMi23333nRNTiVy+JCZfMqCiXleVC/7qq69k/7y8PCfmSxqKpTRsWVa/fn0nppJtfMlxqgTw7373O9lWjVeVIHqkkv7U+1IJjmY6aUolqPoS1FQyme/81ZzhS+gtb9LS0pyYGpNm+pr6NgRQ96+aq3zzvfoeV6W1zcx+/PFHJ/b0009HPpZKRlbJcTk5ObK/SkZViYBm+hqq+9L33aD41mdRy9ar71Ezs+OOO86JzZkzR7ZdvXp12Cl68QszAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEKLMJ/199tlnTsz3ALpKolBJKEdKLAl+KmlGVc1B0bRr186JqapJZmaffPKJE3v//fdl2/vvvz/S8X3JUdWrV3divqpFqgKfqryk3mss5+W7r1QSiu9YqqLZ999/H6mdmdns2bOd2LJly2Tbot7bVMt0qWql6pr4EnNUIp0vaUslbarEIF+VMXVevopmiroHfAlLlStXdmIqQVUlrZnpCpi+Y6lrqKoilkfffPONE7vyyitlW5Wk3aFDB9n2lFNOcWIq4c2X9Dt//nwn9sYbb8i2KhmvU6dOTsz33XDOOedEauubr1XSni9JWyWY1qpVy4mpMWmm7zff+1Lnq+7tpk2byv4qIfiuu+6SbQ8XvzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACHK/C4Za9ascWK+rGuVTZ+cnFzs5+Sjyqr6sslVdqkvExWHT+3Q0KNHD9lWlbX17Vyiyph//fXXTmzevHmyv3rdL774QraNavz48UXqX9GoXRZ8OxdUFKoMeyy7iahsfF/JdjUHqtf1zYsqG99XRluJpeS3yvBX71XtOmCm32ssOxfUrVtXtq0IfGWdX3755Ugxnzp16jixzMxM2bZRo0ZOrE2bNrKt2r1H7Yqkdk4xM3vzzTedWNRdWsz0PVS1alXZVlHnqr7vzPSOGr4dkNS1Vffb66+/Lvs/9dRTMq4c7jzOL8wAAABACBbMAAAAQAgWzAAAAEAIFswAAABAiDKf9KcsXLhQxtVD9Ophd18Cxbp164p0XrGU1S1qWVdEo67phx9+KNuquC+JSJWGbtmypRO76qqrZH+VCLVt2zbZViWOqrHqG38bNmxwYllZWZGOY2aWlJTkxHxJFSqRSbX1lRBWibO+pDF1Xuo9+BJeVP8VK1bItrEkE5Vl6lqpEsK++0KNwVgSBBVfIp4vHlUspbHV+1X9fUl/Ku4r+a0SrNTxU1NTZX9VQhiuvLy8SDEzs5kzZzqxiRMnFvcpoZjEshb7NX5hBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABClMtdMnyZyCrrWsV8GfpF3SVDZTL7sjVVNrbaIQAly1eW95tvvokUI5MaZUlKSooTi2X3nljmMLWrkZrbfTtXRC2j7duNIhbqHGIpw12zZk0n5tvNIuouF+3bt5fxTz/9NPJ5Afg//MIMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhCiXSX/169eX8c2bNzsxlaxRuXLl4j4lM9NJLL6EmVjKqgLA0aDmMDVXVatWTfZX850vEVAdS/El1xU1EU/xJWmr11Vl2LOzs2X///73v04sNzdXtlWJ6iohvU6dOrI/gMPDL8wAAABACBbMAAAAQAgWzAAAAEAIFswAAABAiHKZ9KeS+8x0csrRrKi3YMECJ6YqPJnp89q7d2+xnxMARFWjRg0ntmrVKifmq5b6zjvvODGVHGdmNmLECCc2c+ZMJ+ZLDoyavO1L5IulgqGqIKgSAVNTU2X/Xr16ObHp06fLthkZGU5MfbfVqlVL9gdwePiFGQAAAAjBghkAAAAIwYIZAAAACMGCGQAAAAjBghkAAAAIUS53ycjPz5dxleGtyk3Xq1ev2M/JTO98EQuVCR3LsXzZ4AAQRdOmTZ2YmpeSkpJkf7UjxrXXXivbql0yGjRo4MR27dol+6tdhdR875tX1S4XvtLaVatWdWLVq1d3Ys8//7zsr87r+++/l21zcnJkPMo5ATh8/MIMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhCiXSX++5DpVhjohIcGJtW3bVvZ/++23i3ReKmHEV9ZVxWNJ+gOA4qaS7lRZ6J9++kn2/+abbyIfSyWtjR492omdeuqpsr9Kjlu6dKkTi2VeVe/VzGzt2rVO7MYbb3Ri48ePj3ysxx57TMbPOOMMJ6aSLFu1ahX5WAAOjRUYAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCiXO6S8dJLL8n4cccd58Q2bNjgxKZMmVLs52RmtmXLFifmy9Detm2bE5s9e3bkY1EGG0Bx69ixoxNTuxIlJibK/qo0to8qeX3ZZZdF7h9V5cqVZbxatWpOTM3hZv7dM4pi5syZMq7Kk6elpTmxNWvWFPcpARUavzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIeICssMAAAAAL35hBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCsGCOKC4uzu64446CPz///PMWFxdnS5cuLbFzAkqTpUuXWlxcnD344IMlfSqowJirURHExcXZiBEjDtmO8V98yu2C+cAgOfC/KlWqWLNmzWzEiBG2bt26kj494LB8//33NnDgQMvOzrYqVapYVlaW9e7d2x577LGSPjXgsDBXA4WV5Dx/zz332Ouvv37Ej1MWVSrpEzjS/vrXv1qjRo1s9+7d9tlnn9mTTz5pkyZNstmzZ1vVqlVL+vSAyKZPn249evSwhg0b2hVXXGEZGRm2YsUK++KLL+yRRx6xa6+9tqRPEThszNVA8c/zl1xyiQ0aNMgSExMjtb/nnnts4MCBdu655x7G2Zdv5X7BfOaZZ1rHjh3NzOzyyy+3WrVq2ciRI+2NN96wwYMHl/DZHTk7duyw5OTkkj4NFKO7777b0tLS7Msvv7Tq1asX+ru8vLySOamjbOfOnSyeyinmaqD45/n4+HiLj48PbRMEge3evduSkpJifv2KpNw+kuHTs2dPMzNbsmSJde/e3bp37+60GTp0qOXk5BzW6z/xxBPWunVrS0xMtMzMTLvmmmts8+bNBX8/YsQIS0lJsZ07dzp9Bw8ebBkZGbZv376C2OTJk61r166WnJxs1apVs759+9qcOXOc801JSbFFixbZWWedZdWqVbOLLrrosM4fpdeiRYusdevWziRqZlanTp2C///As22vv/66tWnTxhITE61169b27rvvOv1WrVpll156qdWtW7eg3T//+c9Cbfbu3Wv/+7//ax06dLC0tDRLTk62rl272tSpUw95zkEQ2JVXXmkJCQk2YcKEgviLL75oHTp0sKSkJKtZs6YNGjTIVqxYUahv9+7drU2bNvb111/bqaeealWrVrVbb731kMdE+cBcjYoo6jx/wKHmefUMc05OjvXr18/ee+8969ixoyUlJdnTTz9tcXFxtmPHDhszZkzBI1JDhw4t5ndYdlW4BfOiRYvMzKxWrVrF/tp33HGHXXPNNZaZmWkPPfSQDRgwwJ5++mk7/fTT7aeffjIzswsvvNB27Nhh77zzTqG+O3futLfeessGDhxY8F+DY8eOtb59+1pKSordd9999pe//MV++OEHO+WUU5wH+H/++Wfr06eP1alTxx588EEbMGBAsb8/lKzs7Gz7+uuvbfbs2Yds+9lnn9nVV19tgwYNsvvvv992795tAwYMsI0bNxa0WbdunXXp0sU++OADGzFihD3yyCPWpEkTu+yyy2zUqFEF7bZu3Wr/3//3/1n37t3tvvvuszvuuMPWr19vffr0sZkzZ3rPYd++fTZ06FB74YUXbOLEifab3/zGzH75BeV3v/udNW3a1EaOHGk33HCDffjhh3bqqacWWrCYmW3cuNHOPPNMa9++vY0aNcp69OgR0zVD2cVcjYqouOd5n3nz5tngwYOtd+/e9sgjj1j79u1t7NixlpiYaF27drWxY8fa2LFjbfjw4cXxtsqHoJx67rnnAjMLPvjgg2D9+vXBihUrgvHjxwe1atUKkpKSgpUrVwbdunULunXr5vQdMmRIkJ2dXShmZsHtt9/uvP6SJUuCIAiCvLy8ICEhITj99NODffv2FbQbPXp0YGbBP//5zyAIgmD//v1BVlZWMGDAgEKv/8orrwRmFnz66adBEATBtm3bgurVqwdXXHFFoXZr164N0tLSCsWHDBkSmFlw8803x3qZUIa8//77QXx8fBAfHx+ceOKJwU033RS89957wd69ewu1M7MgISEhWLhwYUFs1qxZgZkFjz32WEHssssuC+rVqxds2LChUP9BgwYFaWlpwc6dO4MgCIKff/452LNnT6E2+fn5Qd26dYNLL720ILZkyZLAzIIHHngg+Omnn4ILL7wwSEpKCt57772CNkuXLg3i4+ODu+++u9Drff/990GlSpUKxbt16xaYWfDUU0/FeqlQhjBXA/+nuOf5g8d/EARBdnZ2YGbBu+++6xw/OTk5GDJkSLG/r/Kg3P/C3KtXL0tPT7cGDRrYoEGDLCUlxSZOnGhZWVnFepwPPvjA9u7dazfccIMdc8z/XdYrrrjCUlNTC36liIuLs/PPP98mTZpk27dvL2j38ssvW1ZWlp1yyilmZjZlyhTbvHmzDR482DZs2FDwv/j4eOvcubP85/CrrrqqWN8TSpfevXvb559/bv3797dZs2bZ/fffb3369LGsrCx78803C7Xt1auX5ebmFvz52GOPtdTUVFu8eLGZ/fKoxL///W87++yzLQiCQmOsT58+tmXLFvvmm2/M7Jdn4BISEszMbP/+/bZp0yb7+eefrWPHjgVtfm3v3r12/vnn29tvv22TJk2y008/veDvJkyYYPv377cLLrig0DEzMjKsadOmzrhOTEy0YcOGFc8FRKnGXA0U7zwfplGjRtanT59iP//yrNwn/T3++OPWrFkzq1SpktWtW9eaN29eaJIsLsuWLTMzs+bNmxeKJyQkWOPGjQv+3uyXf+obNWqUvfnmm/bb3/7Wtm/fbpMmTbLhw4dbXFycmZktWLDAzP7vOb6DpaamFvpzpUqVrH79+sX2flA6derUySZMmGB79+61WbNm2cSJE+3hhx+2gQMH2syZM61Vq1ZmZtawYUOnb40aNSw/P9/MzNavX2+bN2+2Z555xp555hl5rF8nmIwZM8Yeeughmzt3bsE/WZv9Muke7O9//7tt377dJk+e7Dx3umDBAguCwJo2bSqPWbly5UJ/zsrKKliso3xjrgZ+UVzzfBg1dyNcuV8wn3DCCQWZ1weLi4uzIAic+K8TOY6ELl26WE5Ojr3yyiv229/+1t566y3btWuXXXjhhQVt9u/fb2a/PBuXkZHhvEalSoU/usTExCPy5YLSKSEhwTp16mSdOnWyZs2a2bBhw+zVV1+122+/3czMmxV9YLwfGF8XX3yxDRkyRLY99thjzeyXBL2hQ4faueeea3/+85+tTp06Fh8fb3//+98LnjP9tT59+ti7775r999/v3Xv3t2qVKlS8Hf79++3uLg4mzx5sjzHlJSUQn8ma7viYK4GCivqPB+GuTV25X7BHKZGjRryny5+/QtDVNnZ2Wb2y4P0jRs3Lojv3bvXlixZYr169SrU/oILLrBHHnnEtm7dai+//LLl5ORYly5dCv7+wD+z1KlTx+kL/NqBRcaaNWsi90lPT7dq1arZvn37Djm+XnvtNWvcuLFNmDCh4Fc1MyuYtA/WpUsX+/3vf2/9+vWz888/3yZOnFiwaMjNzbUgCKxRo0bWrFmzyOeLio25GhXd4czzh+PXczwKq9D/mZubm2tz58619evXF8RmzZpl06ZNi/m1evXqZQkJCfboo48W+q+7Z5991rZs2WJ9+/Yt1P7CCy+0PXv22JgxY+zdd9+1Cy64oNDf9+nTx1JTU+2ee+4p9E/gB/z6nFExTJ06Vf5yMGnSJDNz/4k5THx8vA0YMMD+/e9/y2zsX4+vA79i/PrY//3vf+3zzz/3vn6vXr1s/Pjx9u6779oll1xS8Cvcb37zG4uPj7c777zTeS9BEETK7kbFw1yNiqI45/nDkZyc7OxWhF9U6F+YL730Uhs5cqT16dPHLrvsMsvLy7OnnnrKWrdubVu3bo3ptdLT0+2WW26xO++808444wzr37+/zZs3z5544gnr1KmTXXzxxYXaH3/88dakSRO77bbbbM+ePYX+ic/sl+fennzySbvkkkvs+OOPt0GDBll6erotX77c3nnnHTv55JNt9OjRRb4GKDuuvfZa27lzp5133nnWokUL27t3r02fPr3gV69Yk+Puvfdemzp1qnXu3NmuuOIKa9WqlW3atMm++eYb++CDD2zTpk1mZtavXz+bMGGCnXfeeda3b19bsmSJPfXUU9aqVatCyVAHO/fcc+25556z3/3ud5aammpPP/205ebm2l133WW33HKLLV261M4991yrVq2aLVmyxCZOnGhXXnml/elPfyrSdUL5w1yNiqK45/lYdejQwT744AMbOXKkZWZmWqNGjaxz585H9JhlRgnszHFUHNhK5csvvwxt9+KLLwaNGzcOEhISgvbt2wfvvffeYW1VdMDo0aODFi1aBJUrVw7q1q0bXHXVVUF+fr489m233RaYWdCkSRPv+U2dOjXo06dPkJaWFlSpUiXIzc0Nhg4dGnz11VcFbYYMGRIkJyeHvk+UfZMnTw4uvfTSoEWLFkFKSkqQkJAQNGnSJLj22muDdevWFbQzs+Caa65x+mdnZzvbBa1bty645pprggYNGgSVK1cOMjIygtNOOy145plnCtrs378/uOeee4Ls7OwgMTExOO6444K3337buU9+va3crz3xxBOBmQV/+tOfCmL//ve/g1NOOSVITk4OkpOTgxYtWgTXXHNNMG/evII23bp1C1q3bn24lwtlBHM18H+Ke573bSvXt29fefy5c+cGp556apCUlBSYGVvM/UpcEER4OhwAAACooCr0M8wAAADAobBgBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQkSu9FeW6ounp6fL+DnnnOPEtmzZ4sRWrFgR+VgrV650YpUq6cuakJDgxFJSUmTbbt26ObFPPvnEiX3zzTeHOsVSryS3Ai9L4xplC+O6+DVs2NCJrVq1Srbdt29fsR9/wIABMv7vf/+72I9V1M/wSI0/xnXJOv30051YgwYNnJgq025m1rZtWyf2j3/8Q7adP3++E1OfQXko5xHlPfALMwAAABCCBTMAAAAQggUzAAAAECIuiPjwSUk/O9SmTRsZ79u3rxPzPUOsnhdWsfj4eNk/Pz/fie3Zs8eJ7dy5U/ZPS0tzYr5zVbZv3+7EKleuLNvOmzfPif3rX/+KfKyjiWfiUB6Vx3Fd1OcX27dv78R27dol22ZmZjqxl19+2Yn5clYeeOABJ7Z+/XonlpubK/tfdNFFTuyYY/RvTBMmTHBiL730khMbPny47H/uuefKuKK+n9RnsH///sivGYvyOK5LI5XHZGY2evRoJ7Z69Won5lsb9OjRw4nNnDlTtj3uuONCzvDQ1P1ypMZlUfEMMwAAAFBELJgBAACAECyYAQAAgBAsmAEAAIAQLJgBAACAEGVml4xbbrlFxlWG9bJly2RblXWdnZ3txNRuGGY6E7VZs2aR2pnpXS4aNWok26rdN+bMmePEkpOTZf+6des6MbVzhpnZ5MmTndjRzG4l6xrlUXkc10WdFzZs2ODEFixYEPlYqr9vlwsVj+X81ffId999J9vWrFnTiVWtWjXS8c303Kx26fA5mtXXyuO4Lo0ee+wxGe/evbsTU7tcqHvFzGzQoEFO7KOPPpJt33//fSc2ZswY2basY5cMAAAAoIhYMAMAAAAhWDADAAAAIVgwAwAAACFKZdJf/fr1ndgNN9wg265cudKJ/fTTT7KtSrpTx6pRo4bsP3fu3Eiv6ZORkeHEGjZsKNvOmjXLicVShrtx48ZOLDU1Vbb961//KuNHC0kkKI8q8rj2JSypcr9qDjczq1SpUqRjqXLXZjqZr0qVKk7MN4cqvjLcqgyxSrpKSEiQ/Vu3bu3EnnvuOdn2vvvuc2LqWv3888+yf1FV5HEdi2HDhsn48ccf78RUkn5KSorsv2/fPidWu3btyP2VtWvXynhiYqIT27x5sxPbtGmT7H/TTTc5sby8PNm2pMtok/QHAAAAFBELZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACBEqdwlo127dk7sxhtvlG0XLlzoxHylqbds2eLE4uPjnVi9evVk/7S0NCe2ZMkSJ+bLTlVluH/88UfZNuruG+r8zXTJbh92yQCKX0Ue11999ZWMq/lq27Ztsq3avSKW96V2idixY4cTq1atmuyvztWXta9eNykpyYmp3TTMzJKTk52Y73uoUaNGMn4w37Uq6risyOPa5+STT3Zid9xxh2y7d+9eJ6Z2wFKl1c30zhVqlwy1I4yZ2fz5852Yb/cXtQ5Rn4FvzTNjxgwnds0118i2JY1dMgAAAIAiYsEMAAAAhGDBDAAAAIRgwQwAAACEiFZ79ChTSRi+JDiVAOErvagelldlJpcuXSr7q/KVLVq0cGK+c/3uu+8iHd9Mn6tKLGnSpInsrx7iX7ZsmWwLAIdLzUE1a9aUbVXitW8OVMlFKjHHl4in+qt58aeffpL9VdKgL2lPJV2tW7fOiTVt2lT2V+fgS/qKWkL4SCX9wTVw4EAntmrVKtlWJeOpz8pXsn3jxo1OTCXO+vqre1OVcTeLPtZ85elzcnKc2CmnnCLbfvbZZ04s6hxwtPALMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCiVCb9qQpHa9eulW1VhZ2TTjpJtv3Xv/7lxNQD+OpBdzP9sP3mzZtlW0UldvgSVipVcj8a9RC/r+qTOlcAKG6qgqkv4UwldO/atUu2VcnTKuarMqaq5+3evduJ+eZ7leC3detW2VZVgY0lIVwlPq5cuVK2VXP+okWLnBjJfcXPl2SvNgRQCa4+ah3iuy9q1KjhxNasWePEVEVBM7PMzEwn5ksQVBsNqLWJ7x5SibMXXXSRbKuS/krbGOYXZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgRKncJUNlgfqyOOfOnevEunfvLts+88wzTiw+Pt6J+Uq1qqxp1V+VtTYzS0pKcmK+TNglS5Y4MZVh7sva/fHHH52YyuQ2i17+EgAOdvzxx0duq3YKqlOnjmyrdpRQGfq+OVTNzWoOVpn8vrhvVyLVVn2PqOOb6d03EhISZNvc3FwnpnbJoDR28evdu7eMq10ufOsItbNWLOsItRaqXr26E9uzZ4/sn5+f78R85eHVOkCNS9+OHOoapKamyrZlAb8wAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACFKZdJf1apVnZjvAfi8vDwnduyxx8q25557rhNTJaR95UvVw/IqEdBHtfUl7WVkZDgx9bC9KktrphNhfMk1JP2hKFQJ4pycHNm2bdu2Tmz8+PGRj1XUsaoSoUiCKppWrVo5Md81VZ+fSngyM6tdu7YTU/N9LMnM6ntEzeu+tr7vhlq1ajmx9evXOzFf0uCGDRucmO+6qJLb77//vhNjXBe/bt26ybj6vvUlt6ly0yoRUCX5m+lS8Crp1FeuWiX4+RJf1dyq3qsvwVAluapNHcz0uFabOpQkfmEGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKUyl0yFF8mvIrPnj1btlXZmSrr2XcslQmqdr7wZaeqrGdfJq16XZUdqzKxzfR78GVdqwzvdevWybaouG6++WYZv+iii5zYihUrZNvWrVs7MTXWpk6dKvvHsiNGLGXvFbXLQK9evWTbDz/8MPLrljeZmZlOzLdDg8qa97VV5X7VjhirV6+W/dWuQmqHAF9ZX1XuWO1eZKZ3uVDvVe38YWa2fPnyyOfVvn17GT8Yu2QUP9/3tfoeVrt9mfnLUB9M7aZhpsd11J03zMyaNm3qxLZt2ybb+nYnO5hvzaPma1/bjh07OjF2yQAAAADKEBbMAAAAQAgWzAAAAEAIFswAAABAiFKZ9KeS0NauXSvbqgfgp0yZItuqhA1f0pyiHtaPmghoZlapknu5Fy1aJNuq19i5c6cT++yzz2R/leDoS3iKpbw3So4q62xW9OSe9PR0JzZt2jQnppJFzMz+53/+x4k1bNhQtlVJfx988IETe/PNN2X/P/zhD05s6dKlsm3UBD/ffKGSZjp16iTbVuSkv9zcXCfmK7WrxpqvrK5KHFVJc40bN5b9VRltNQdnZ2fL/qo0sXpNM30PqqRTlUhoFj1B0UyXEEbxUwlvvjlFJbL5ktvU920sc7g6h+TkZCfm+75Q/dV94RNL4rU6L981VEl/L774YuRjHQ38wgwAAACEYMEMAAAAhGDBDAAAAIRgwQwAAACEKJVJf+pBcV9iSOfOnZ3YvffeK9teddVVTkw9gO6riKcq96hEvFge9leVBs3M6tSpE+m8Vq1aJfurhJWNGzdGPtbKlStlW0SjEi5UYkcsiXyxJIaoilR33nmnbDts2DAn9tBDDzmxK6+8Uvb//e9/H/m81P2ixpqvot6SJUuc2EcffSTbjh8/3okNHjzYidWrV0/2V+fVs2dP2dY351QEKsHYVylUVSTbtGmTbKvmS5WkrY5vpudrX/U8RSX4+RKe1JyvjuW7h1Wiu2++VkmWKH7qOvs+PzUufGNFfY+r+8K3DlHnELUin5lOyPWtWVRblSDo+x6LunmBmT95tzThF2YAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgBAtmAAAAIESp3CVDlQ/1lQlVu1yokrZmOutUxXylon3ZnQfz7eihsrZ9mbAqa3Xbtm1ObPbs2bL/JZdc4sR+/PFH2bZ+/fpO7JtvvpFtKzL1mfgyoaPuaBHLzhc5OTky/txzzzmx7t27OzG1S4yZWdu2bZ3YmjVrnJjaTcNM7zKxbNky2Vbt3qKuq2/3F3UP+XauUHG1K43vWGq3nnbt2sm2FcXxxx/vxNQY9s2hCxcudGK+66/KkO/atcuJ+XbZUJ+1OldfWWAV992vUcuw+85VjWtfW/Wdocp7++5BRFOzZk0n5iv5Hss8vnv3biemdpnw7Vyhyqjn5+dHipmZNWvWzImpXTrM9FhT6yDfTjXqHvIdq0GDBjJemvALMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCixJP+VGKNSvDzJdypUqnNmzeXbVNSUiIdSz1UH4tYyq/6qIQVVe7Y92D/nDlznJiv1KpKGKkoopawNvMn+B0J119/vRPzJe2p97BgwQIn9vHHH8v+d9xxhxO79NJLndiMGTNk/8zMTCdWt25d2VaNV1XW1VfqVSXMfPvtt7KtSi5RSYdJSUmyv7qPGzVqJNv65pzyRiXmqIS32rVry/7vvPOOE/MlAZ166qlOTN2DvrK8voTqqNTn7zuW+s5Q3y2++VrNwb5kSJWQG0viLaJRc0Us5a5j+b5Q3+1qDWCmx6VKrlPnb6Y3JfDdK6qtut9994W6Br7vVzXe1XXZunWr7H808AszAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEKLEk/5UVT/1sLsvCUhVpPMlHKnEQZWY4avmo0StHujjqzKlHmxXCTe+xIK8vDwnphKmzPzXtiJQCQhNmjSRbc8//3wnpqovmpkdd9xxkY7vq5DUtGlTJ/aXv/xFtj333HOd2ODBg52Yr9Kjut9GjRrlxP7whz/I/mPHjnViF198sWy7du1aJ6Y+g1gqKPqqyqmEYsWXpBtL9a6iJpiVFar6mfqsfPOamq9V9T4zXenMV/FVUfO4+r7xfc6xjDV1DVT1Pl8inmqrYmY6wapjx45O7IsvvpD9EY0aK74qvrEkwqkkY9XWNweqe0Al+KnzN9Pj2jcHqnNQsS1btsj+vnNQ1Bxap04dJ0bSHwAAAFBKsWAGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQpT4Lhm1atWK1M6XnbphwwYn1q5dO9lW7QaQlpbmxFTGq5nODlWZ3D4qu1WV6zYzW716daTzUqUjzfS5+jJW09PTZbyimjhxooyrXUoef/xx2Xb27NlO7KSTTnJiqqy0mdnKlSudWL9+/WTb9u3bO7F169Y5MV8JYrUrSIsWLZyYL8Nf3QO+sq7Vq1d3Yio72rfLQlF3TlA7xfh2SVD3m2+nGXW9yyM1X6rr79s1RO0qs3nzZtk2atl633yt+vt2Loja37dzgYqr77Zp06bJ/ps2bXJiJ554omyr7i3fzj44fOq72TfXqDGovsPN9He2ui9iKcOt5nbfmkntdOObA9Wx1DrCtwOT2n1DfQeY6bk9IyPDiS1cuFD2Pxr4hRkAAAAIwYIZAAAACMGCGQAAAAjBghkAAAAIUeJJf6pMpHqw3pcEpB4qV6/pe131sL7vYXtVQlr195XWVskavnNVD9ur/r5jbdy40YnVr19ftvW934pAJe3l5ubKtjNnznRigwYNkm1VwogaK77yzb5SpYoqN62SQHzva9GiRU5MJSyphC8zXdrYV75UjVdf0pcSy1hVx1KljX0JaioRJpbSuOWRrzT0wXzJdaqEryoDb6Y/a3V8X8KSmq9VW9+5qu8c3+evzlV93/iuX15enhOrXbu2bKvKEPuSv3H4VHKb7/tWfY+redlMJ3qr72vfhgIqvnPnTiemEknN9LiKJelPjbWlS5dG7t+lSxfZVt1Dar4oSfzCDAAAAIRgwQwAAACEYMEMAAAAhGDBDAAAAIRgwQwAAACEKPFdMqKWtfVlsufn5zsxXyay2mVCZfj7duSImiHuy5hXOx+o45vp8pHr16+PfE6+MsiKyrBVmbjlcTeNCRMmOLH+/fvLtlFLUJvpbHo11n1Z1wkJCU7Ml8mssp7VWJs7d67sr8b7mjVrnNi8efNkfzUufOeqRL2vzPSOBrGUp4+lNLK6j6tWrSrbtmvXLvLrlmVRP2vfZ7J8+XIn1rFjR9lWzY1qXPuOpb4zYimXreK+sarGipqDfSWs1b0Zy3wbyz2EaNS86PtuV5+V2s3ETJfBVmNF7bRkpr9H1HeAbwcm9d0Uyy5kderUiXROZnqnELV7jZm+Br4y2iWFX5gBAACAECyYAQAAgBAsmAEAAIAQLJgBAACAECWe9KfKT6oHyH1JfyppylduWpWfjFqa20wnDaokIF9iUCzlc1VpYpX0V7NmTdnfl4ym+Mq9VgQffvihE2vQoIFse9NNNzmxiy++WLZt27Zt0U5MiCUJSI01X3KUSuxQSSAkFvmdccYZJX0KR4Uag2pc+ZI+1XzbqFEj2VbNt7GMa/WdEUtpbMWXHKWui5pXfaV+1XzhK22s7sPymJBd0lTitS9JW32u3377beS2sZQ2V5+1msN96w01fmJZm/iS9pQFCxY4sbp160Zum56eHvlYRwO/MAMAAAAhWDADAAAAIVgwAwAAACFYMAMAAAAhSjzpTyW3qWQJ9VC7WWzVuFavXu3E1AP0aWlpsn9eXp4TUwknvuQo1dZXzUddA9Xflyzw7rvvOjFfNTJ1DdTD9rEkEpZH999/f6SYj6qQ1KpVK9lWVT+rV6+ebBu1GpLvHlKJTFETS8x0RTZfIqmK796924n5ErHUefkSntT9ot6DL7lKVanyHWvq1KlO7Oabb5ZtyzL1/lVynW+snH322U7Ml9ijxkXUsRrLefnGmkoQ9B1Lzfkq5rsuWVlZMq5EHdcoGpXc5tt8QH3WW7dujdw2atKomd4oQW0IoCr4mpkde+yxTmzDhg2yraLul4yMDNlWVfaM5X5TiZcliV+YAQAAgBAsmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQJb5LRtQy2Js3b5b9VVtf1vXChQsjnVN+fr6Mq3NQmdw7duyQ/dW5+rJuVYauivmytlWGrW/3DvUZxFL+EtGoXVZUzMzs448/PsJnA8ROzSsq6903rnv37u3E5s+fL9tGLU0cS2nrqGXgzfRuFL5jqeui5lBfCeKNGzc6MbWrjpme82vWrCnb4vCp3Sh839eKb1yp11Djyvd9rfrXqFHDifnGhCo57ysvr+JqfdO8eXPZf/r06U7Mt/uH2iXDd14lpXSdDQAAAFDKsGAGAAAAQrBgBgAAAEKwYAYAAABClHjSn3qwXSVLqOQ6n++//17G1cPuqqxwZmam7N+gQQMnps7V96C6KiGsEu7M/ImHB0tKSpJxVXJbvX9fW195cQAVl0rMUTGVnGemE/nq168v26qkJTUvquOb6aQtdV6++dr3uopK5ktNTY18LPU94EsQVEl/sSQ+Ihp1nX2JeIqvrLP6vlXJqLEk3qvx4ztXNa58yYwqrpL+atWqdahTPCR1b5D0BwAAAJQhLJgBAACAECyYAQAAgBAsmAEAAIAQLJgBAACAECW+S4bKWlY7P6gdJsx0FuWgQYNk25UrVzqxVatWOTFfuemdO3c6MVUu25fZqbJWfWW8mzRp4sTUjh6+8qkPP/xw5PNS2dy+awCg4lK7FandJHxZ96os7rRp02Tb5OTkSP19O0T4dik4mG8HpljKaEctbbx+/XrZ/+STT3ZiDRs2lG3VbkdqBycUzZYtW5yY2uHCzGzTpk1OrG3btpGPpdZBvl1aou4ipsqtm5k1a9bMiamdL3zULhu+XbUaN27sxPLy8mRbNWeonW5KEr8wAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACFKPOlPJVGoBD9fctsXX3zhxC677DLZViW9ZWRkRD6WeuA/ljKT69atc2IqscRMJxGoJIR58+bJ/oqv1ObWrVudmC+5AUDFpZLbVMKSb6559tlnndi9995b9BMr49R31n333Sfbqu8RlRCOotmwYYMTU0mnZjpJ/pRTTpFt1fe4Wpv4SqOrzQeqVavmxHyJeL4kVyXq+kadk5nZWWed5cRUGW8zneRb2vALMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCixJP+VJU59aC5aufz1VdfFemcyitftURVbTAzM9OJffPNN8V+TgDKDpVclJ+f78R8SWhqXvFRiVC+6mdF4asUGMux1Guo81cJkmZmOTk5kY8ftaogikZV8fVdZ1Wd+JlnnpFtf/vb3zqxWrVqOTFfZV6VYJiWlubEfNX7VPU831hTCX7qGvgSCSdNmuTEunXrJtuqhMr//ve/sm1J4RdmAAAAIAQLZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACBEie+SoXZoUHzZxbFQZbiL43WPFpU1qzJmY+kf62sAqLiilvD1zSmxlL89WvNScey8UdTXWL9+vRPzlUZWpYVXrFjhxNTOCWa6NDNcy5Ytc2KxfM5vv/125Hj79u2d2LHHHiv716hRw4nVq1fPian1jpnZ3r17nZivjLYalx9++KET++KLL2R/pUuXLjKudu9Qxy9J/MIMAAAAhGDBDAAAAIRgwQwAAACEYMEMAAAAhCjxpD9FPfydmJhY5NctSwl+SlGTYHzXUCUHqFKfACq2zp07OzGVCKhK6pr5E5nKI1/JbUUlbfkSsVTipCpX3KtXL9n/3//+d+Tzqshyc3OdWMOGDWXb5cuXOzGVnGemS8nPnDkzUqw88JUXV/dAzZo1j/TpxIRfmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQLJgBAACAECW+S8a6deucmMqiVFmoiM38+fNlvFGjRk5s8+bNR/hsAJQ106ZNc2Jq14atW7fK/t98802xn1NpFcsuGU899ZQT85URV7saLVq0yIm98cYbkY8P13vvvefEmjdvLtuuXbvWiandMHzUTjNHqzR8GDWGVSyWc506daqML1iwwIn95z//ify6RwO/MAMAAAAhWDADAAAAIVgwAwAAACFYMAMAAAAh4oIgCEr6JAAAAIDSil+YAQAAgBAsmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQLJgBAACAECyYAQAAgBAsmCOKi4uzO+64o+DPzz//vMXFxdnSpUtL7JwAn6FDh1pKSsoh23Xv3t26d+9ebMft3r27tWnTptheD/g1xjXwi7i4OBsxYsQh27FWKT7ldsF8YJAc+F+VKlWsWbNmNmLECFu3bl1Jnx7geOKJJywuLs46d+5c0qdSJt1zzz32+uuvl/Rp4CCM66JhXFc833//vQ0cONCys7OtSpUqlpWVZb1797bHHnvsiB+b8eZXbhfMB/z1r3+1sWPH2ujRo+2kk06yJ5980k488UTbuXNnSZ8aUMi4ceMsJyfHZsyYYQsXLizp0ylzmOhLJ8Z10TCuK5bp06dbx44dbdasWXbFFVfY6NGj7fLLL7djjjnGHnnkkZhf75JLLrFdu3ZZdnZ2pPaMN79KJX0CR9qZZ55pHTt2NDOzyy+/3GrVqmUjR460N954wwYPHlzCZ3fk7Nixw5KTk0v6NBDRkiVLbPr06TZhwgQbPny4jRs3zm6//faSPi2gSBjXQGzuvvtuS0tLsy+//NKqV69e6O/y8vJifr34+HiLj48PbRMEge3evduSkpJifv2KpNz/wnywnj17mtkvE7nvObehQ4daTk7OYb3+E088Ya1bt7bExETLzMy0a665xjZv3lzw9yNGjLCUlBT5C/fgwYMtIyPD9u3bVxCbPHmyde3a1ZKTk61atWrWt29fmzNnjnO+KSkptmjRIjvrrLOsWrVqdtFFFx3W+aNkjBs3zmrUqGF9+/a1gQMH2rhx45w2S5cutbi4OHvwwQftmWeesdzcXEtMTLROnTrZl19+echjzJw509LT06179+62fft2b7s9e/bY7bffbk2aNLHExERr0KCB3XTTTbZnz57I7+frr7+2k046yZKSkqxRo0b21FNPOW3y8vLssssus7p161qVKlWsXbt2NmbMGKfdjh077MYbb7QGDRpYYmKiNW/e3B588EELgqCgTVxcnO3YscPGjBlT8BjW0KFDI58vjgzGNeMasVm0aJG1bt3aWSybmdWpU8eJvf7669amTRtLTEy01q1b27vvvlvo79UzzDk5OdavXz977733rGPHjpaUlGRPP/004+0QKtyCedGiRWZmVqtWrWJ/7TvuuMOuueYay8zMtIceesgGDBhgTz/9tJ1++un2008/mZnZhRdeaDt27LB33nmnUN+dO3faW2+9ZQMHDiz4r8GxY8da3759LSUlxe677z77y1/+Yj/88IOdcsopzgP8P//8s/Xp08fq1KljDz74oA0YMKDY3x+OnHHjxtlvfvMbS0hIsMGDB9uCBQu8i4WXXnrJHnjgARs+fLjdddddtnTpUvvNb35TMMaUL7/80nr27GnHHXecTZ482Zs4tX//fuvfv789+OCDdvbZZ9tjjz1m5557rj388MN24YUXRnov+fn5dtZZZ1mHDh3s/vvvt/r169tVV11l//znPwva7Nq1y7p3725jx461iy66yB544AFLS0uzoUOHFvpnxyAIrH///vbwww/bGWecYSNHjrTmzZvbn//8Z/vjH/9Y0G7s2LGWmJhoXbt2tbFjx9rYsWNt+PDhkc4XRw7jmnGN2GRnZ9vXX39ts2fPPmTbzz77zK6++mobNGiQ3X///bZ7924bMGCAbdy48ZB9582bZ4MHD7bevXvbI488Yu3bt2e8HUpQTj333HOBmQUffPBBsH79+mDFihXB+PHjg1q1agVJSUnBypUrg27dugXdunVz+g4ZMiTIzs4uFDOz4Pbbb3def8mSJUEQBEFeXl6QkJAQnH766cG+ffsK2o0ePTows+Cf//xnEARBsH///iArKysYMGBAodd/5ZVXAjMLPv300yAIgmDbtm1B9erVgyuuuKJQu7Vr1wZpaWmF4kOGDAnMLLj55ptjvUwoBb766qvAzIIpU6YEQfDLGKlfv35w/fXXF2q3ZMmSwMyCWrVqBZs2bSqIv/HGG4GZBW+99VZBbMiQIUFycnIQBEHw2WefBampqUHfvn2D3bt3F3rNg++BsWPHBsccc0zwn//8p1C7p556KjCzYNq0aaHvpVu3boGZBQ899FBBbM+ePUH79u2DOnXqBHv37g2CIAhGjRoVmFnw4osvFrTbu3dvcOKJJwYpKSnB1q1bgyAIgtdffz0ws+Cuu+4qdJyBAwcGcXFxwcKFCwtiycnJwZAhQ0LPD0cP4/oXjGvE4v333w/i4+OD+Pj44MQTTwxuuumm4L333isYYweYWZCQkFBorMyaNSsws+Cxxx4riB28VgmCIMjOzg7MLHj33Xed4zPe/Mr9L8y9evWy9PR0a9CggQ0aNMhSUlJs4sSJlpWVVazH+eCDD2zv3r12ww032DHH/N9lveKKKyw1NbXgF+W4uDg7//zzbdKkSYX++fDll1+2rKwsO+WUU8zMbMqUKbZ582YbPHiwbdiwoeB/8fHx1rlzZ5s6dapzDldddVWxviccHePGjbO6detajx49zOyXMXLhhRfa+PHjCz2ec8CFF15oNWrUKPhz165dzcxs8eLFTtupU6danz597LTTTrMJEyZYYmJi6Lm8+uqr1rJlS2vRokWhcXfgUSY17g5WqVKlQr9KJCQk2PDhwy0vL8++/vprMzObNGmSZWRkFMojqFy5sl133XW2fft2++STTwraxcfH23XXXVfoGDfeeKMFQWCTJ08+5PmgZDCuf8G4Rix69+5tn3/+ufXv399mzZpl999/v/Xp08eysrLszTffLNS2V69elpubW/DnY4891lJTU+U9c7BGjRpZnz59iv38y7Nyv2B+/PHHbcqUKTZ16lT74YcfbPHixUdkkCxbtszMzJo3b14onpCQYI0bNy74e7Nfvhh27dpVMPi3b99ukyZNsvPPP9/i4uLMzGzBggVm9ssz1+np6YX+9/777zsP/1eqVMnq169f7O8LR9a+ffts/Pjx1qNHD1uyZIktXLjQFi5caJ07d7Z169bZhx9+6PRp2LBhoT8fWGTk5+cXiu/evdv69u1rxx13nL3yyiuWkJBwyPNZsGCBzZkzxxlzzZo1M7NoSSeZmZlOwumB/gceJVq2bJk1bdq00H9cmpm1bNmy4O8P/N/MzEyrVq1aaDuULoxrxjUOX6dOnWzChAmWn59vM2bMsFtuucW2bdtmAwcOtB9++KGg3cH3jNkv983B94zSqFGjYj3niqDc75JxwgknFOyScbC4uLhCCRYHqF8/ilOXLl0sJyfHXnnlFfvtb39rb731lu3atavQs3T79+83s1+eYcvIyHBeo1Klwh9dYmKiM0mj9Pvoo49szZo1Nn78eBs/frzz9+PGjbPTTz+9UMyX8XzwWE5MTLSzzjrL3njjDXv33XetX79+hzyf/fv3W9u2bW3kyJHy7xs0aHDI1wAY10DRJSQkWKdOnaxTp07WrFkzGzZsmL366qsFO81EvWcUdsSIXblfMIepUaOG/KeLw/mv+wN7HM6bN88aN25cEN+7d68tWbLEevXqVaj9BRdcYI888oht3brVXn75ZcvJybEuXboU/P2Bf2apU6eO0xflx7hx46xOnTr2+OOPO383YcIEmzhxoj311FOHNbnFxcXZuHHj7JxzzrHzzz/fJk+efMjqZ7m5uTZr1iw77bTTCv61I1arV692tjWcP3++mVnB7jPZ2dn23Xff2f79+wv9h97cuXML/v7A//3ggw9s27ZthX6NO7jdgfeL0oFxzbhG8Trww9+aNWuO6HEYb34V+ifJ3Nxcmzt3rq1fv74gNmvWLJs2bVrMr9WrVy9LSEiwRx99tNB/3T377LO2ZcsW69u3b6H2F154oe3Zs8fGjBlj7777rl1wwQWF/r5Pnz6Wmppq99xzj8wS//U5o2zatWuXTZgwwfr162cDBw50/jdixAjbtm2b89xaLBISEmzChAnWqVMnO/vss23GjBmh7S+44AJbtWqV/eMf/5Dnu2PHjkMe8+eff7ann3664M979+61p59+2tLT061Dhw5mZnbWWWfZ2rVr7eWXXy7U77HHHrOUlBTr1q1bQbt9+/bZ6NGjCx3j4Ycftri4ODvzzDMLYsnJyYW2cETJYFwzrnH4pk6dKn8hnjRpkpm5j30WN8abX4X+hfnSSy+1kSNHWp8+feyyyy6zvLw8e+qpp6x169a2devWmF4rPT3dbrnlFrvzzjvtjDPOsP79+9u8efPsiSeesE6dOtnFF19cqP3xxx9vTZo0sdtuu8327NnjbG2UmppqTz75pF1yySV2/PHH26BBgyw9Pd2WL19u77zzjp188snOZIuy5c0337Rt27ZZ//795d936dLF0tPTbdy4cZG3vlKSkpLs7bfftp49e9qZZ55pn3zyibVp00a2veSSS+yVV16x3//+9zZ16lQ7+eSTbd++fTZ37lx75ZVXCvbtDJOZmWn33XefLV261Jo1a2Yvv/yyzZw505555hmrXLmymZldeeWV9vTTT9vQoUPt66+/tpycHHvttdds2rRpNmrUqIJf3c4++2zr0aOH3XbbbbZ06VJr166dvf/++/bGG2/YDTfcUCjhpUOHDvbBBx/YyJEjLTMz0xo1akQ55hLAuGZc4/Bde+21tnPnTjvvvPOsRYsWtnfvXps+fXrBv0QPGzbsiB6f8Rai5DboOLIObKXy5ZdfhrZ78cUXg8aNGwcJCQlB+/btg/fee++wtpU7YPTo0UGLFi2CypUrB3Xr1g2uuuqqID8/Xx77tttuC8wsaNKkiff8pk6dGvTp0ydIS0sLqlSpEuTm5gZDhw4Nvvrqq4I2v95qCWXH2WefHVSpUiXYsWOHt83QoUODypUrBxs2bCjYfuuBBx5w2h08PtWY2LBhQ9CqVasgIyMjWLBgQRAE7vZbQfDLNlj33Xdf0Lp16yAxMTGoUaNG0KFDh+DOO+8MtmzZEvqeunXrFrRu3Tr46quvghNPPDGoUqVKkJ2dHYwePdppu27dumDYsGFB7dq1g4SEhKBt27bBc88957Tbtm1b8Ic//CHIzMwMKleuHDRt2jR44IEHgv379xdqN3fu3ODUU08NkpKSAjNja6QSwrhmXOPwTZ48Obj00kuDFi1aBCkpKUFCQkLQpEmT4Nprrw3WrVtX0M7Mgmuuucbpn52dXWiM+LaV69u3rzw+480vLggiPB0OAAAAVFAV+hlmAAAA4FBYMAMAAAAhWDADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACEiV/qjvjiOlJLcCrw8jOv4+Hgntm/fviK9ZqVK7tTQrFkz2bZBgwZOrH79+rKtKutar149J5acnCz7q7YbNmyQbT/55BMn9sQTTzixnTt3yv5FxbhGecS4Ln5qXhw8eLBs+8MPPzixk046yYnNmzdP9l++fLkT69Spk2z7wQcfOLHPPvtMti3rooxrfmEGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQsQFEZ/gL60P28dyXlGTFVQSlZnZq6++6sTUA/SVK1eW/Xft2uXEevXqJdtecMEFTmz+/PmyrXLMMe5/C/nef0kmcZT08UvruFbUZ2pmtn//fidWpUoVJ3bzzTfL/u3atXNi7du3d2I1a9aU/VNTU2W8KNasWSPj6t7csmWLbKviK1eudGLnnXee7K/GRixjlXGN8ohx7erYsaMTy87Olm27dOnixNR87bvOixcvdmIpKSlO7Pvvv5f9q1atKuNKVlaWE0tLS3Nin376qez/5ZdfOrHNmzdHPv7RRNIfAAAAUEQsmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQZWaXjFh2CIiFyvxX5XPNzBISEpyYui7VqlWT/X/++Wcntnv3btl227ZtTuzOO+90YgsXLpT9yxKyrqNJTEyU8T179jixQYMGObGxY8fK/moMqXHp241C3Rc1atSQbdU9oHbZ8N1D6r5Yu3atbJuRkeHENm7c6MSOP/542b+oGNc4ElTZenVfHSllZVwXdZebiy66yImpOcXMLDk52Yn55qVFixY5MbVLxr59+yIfS83BvjGhros6vpnemUu9rirtbabncd/3yKZNm5zYe++9J9seCeySAQAAABQRC2YAAAAgBAtmAAAAIAQLZgAAACCEmz1QSsWS3KfKVJqZnX/++U4sMzPTiamH6s30Q/gbNmxwYiopw8wsPz8/cluVjHjfffc5MV+57HHjxjmx2bNny7YoG3766afIbVUSx/bt22VblUinxuWsWbNkf5Vw4iujXatWrUjH9yVgqHlAlfY209dAvS9fae+tW7fKOMoulTzuG2tFTW4788wznZgvwfSMM85wYqossZn+zrnllluc2I8//ij7r169WsbLm1g+v0suucSJnX766U7stddek/2XLl3qxJKSkiIfXyXC+dY8qrS0Wsf4kv7UvObbVEFdQ/W+FixYIPur96DKeJuZde/e3YmpJO2vvvpK9j8a+IUZAAAACMGCGQAAAAjBghkAAAAIwYIZAAAACMGCGQAAAAhRZkpj+6hy0c2aNZNt9+7d68R27NjhxHzvVe0GoMo5Nm3aVPZfsWKFE/Nl0qoyyCrD31cuOT4+3on98MMPsq3KsD6aykqp1ZIWS3n4Rx55xIkNHDhQ9p8zZ44Tq1+/vhP7/vvvZf/atWs7Md/uL/Xq1XNiq1atcmJVq1aV/evWrevEfGW01W436r74y1/+Ivvfe++9Mh4V47r0UfdQLDswnXfeeTL+6KOPOjF1D/l2E1Dj0ndealxXrlzZian70kx/D3Tu3Fm2VTvrlOVxrXbpMTM766yznFidOnWc2Lx582R/tY5QOzyY+ctQH6yo5c59pbV3794d+ZzUZ63m5l27dsn+amcntY4y098Z6rwWL14s+xd19xdKYwMAAABFxIIZAAAACMGCGQAAAAjBghkAAAAIUWaS/i6++GIZV0kY69atOyLnoB5WV0l3vpK6vkQoRb2uSgJQySJmOrlFJVyZmc2cOdOJ3XTTTYc4w+JTlpNIjibfuarrN378eCfmKxmvkihatmzpxGJJ+vOVP1Xnqkr9+pJQWrVq5cRUaW0zsxo1akR+XaWoY4NxXfqoJGtfwtKVV17pxFSSuZlZfn6+E1NzsC/hSSXtqRLIZrqUuxprKhHNTCe+paWlybbqepXlcX3SSSfJeG5urhNTn59vrCxfvtyJ+b7v1WetkuN8SX8qrs5VbXLg45sX1bHU+1LJob62vmOpZNZly5Y5MZWMaWY2ffp0GY+KpD8AAACgiFgwAwAAACFYMAMAAAAhWDADAAAAIaJnoZUwXyUiX8JPVCqJwPfwt6q8tGfPHifmq96nHuz3JQaoY6mYr796D77KQ8cff7yMo3SJJdlGVXnyJaz4xuvBfMkWqvKTSmwxM9u5c6cTU4lQvkp/qn/16tVl21tvvdWJPfzww07siy++kP2HDh3qxJ5//nnZFqWPmhvVPdClSxfZ/3/+53+cmC8RT91DqgKlGr9mOnnbV8VV3VsqwSsrK0v2X7p0qRNT32NmZiNGjJDxsqpBgwYyrhLRVBVflXBpphOfVUU9X9w3X0alkvOKmsjna6v4+qtz8H2PqEp9as0USzJjceMXZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACAEC2YAAAAgRJnZJcOXnaoyTn0Zm1FLXfoyVqPuUhBLJrWv1KeKq5jKIjXT79WX8VrUDF0Uv1h2b1EaNmzoxHxZ9774wWIpd+3LEFdjUI0/tSOMmc6Q9u3ysWDBAhk/2FlnnSXj77zzjhNjl4zyR5W1NtM7R/juFfWdo3bE8GX4q7LAvnEdy85MitqRIz09PfKxyrJ69erJ+JYtW5yYKiHu+/xVGXLfrkTqs/aNQUWNIbUO8H2vx7LLhGqrxrqvtLrarUnFzPSuMur4qp2ZHsPr16+XbQ8XvzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIcpM0p+vzKN62N33UPiGDRucWCyJVCqRTiVn+R5qV219yU3qvNTxfclV6gF433tViVg1atRwYrEkJqBo1GflSxBVbVXC2kUXXST7q4Qhda/4kmlVcokaq2b6XGNJ1ohaqtXMrE+fPk7s7bffdmKqBK6Z2QsvvBD5WCh9fPPwwebNmyfjKjkulnLDaqz7zknNrbGMdXVevuQulbjmO69//OMfTuyZZ56JfF4lqW7duk7MN4epa6Wuk6+0tlqHbNy4UbZVcfVZ+z5/9R6iJm6bxbaOUG1VTJVbNzNr1KiRE1NJj2b6uqj3um3bNtm/VatWTuyTTz6RbQ8XvzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACHKzC4ZvjKPaueAjIwM2TYvLy9Sf9/OFSprWmUX+8p4q2PFspuAOr4vE1rtcrF161bZVmWiZmdnOzF2ySg77r333kgxM71LQPXq1Z2Yb+cKVQLYR41hNf6mTp0q+/fq1cuJ+cbl0KFDndi11157iDP8P08++WTktih9YtkBSVE7xaiS82a6tLJvblfUd45vN4Gotm/fLuNqRwX13VjWnXjiiU6sW7dusu1LL73kxBo3buzE+vbtK/s/+OCDTsy3c4T6XGMpVx11XPnaqR1VfGW81Q5C6r5ISEiQ/dVOHz169JBtv/76ayf27rvvOrEOHTrI/uo7i10yAAAAgKOIBTMAAAAQggUzAAAAEIIFMwAAABCiVCb9paSkODGVLGSmEzt8SXfqdX2JcIo6B5Ws4SthHEsSiKLeqy9BsU6dOk5sx44dsq06X9UfJauoSUw+qjR2WlpapJiZHj8qMcRMj9cZM2Y4MZW0aqYTO3xJfzk5OU6sX79+TkyVyzaLnuSL8mnhwoVO7LjjjpNt16xZ48SqVq3qxHzljlXcl0yr7qHatWs7MZWIaGZWq1YtJ/bDDz/ItmXZ66+/7sR8iXhDhgxxYjfccIMT+/LLL2V/9d2anp4u20Yt9+xL+vR9jx/MtzZQ6yNfaWw1hn2vq6gxnJubK9v+7ne/c2K33nqrE/vvf/8r+7/zzjuRz+tw8QszAAAAEIIFMwAAABCCBTMAAAAQggUzAAAAEKJUJv2pJKRYKuL5qIftVbKFr2qNqsajKhD6zkklDPmSiNT7VTFfMqRKAlm+fLls+9NPPzkx9bA/SieVdKfGhS/hSFX5Ugmy6v7xtd28ebNsq6oFqrHapEkT2V/dA6pymZlOZHnhhRecWM2aNWV/Evwqtm+++caJnX/++bKtGitRk7PMdPU13/22ceNGJ6a+s/bs2SP7q2Q0Ve2zPJo5c2bkuPq+XLRokez/29/+1omNGTNGtvXNVwfzzddqzaGS63ybH6jvBt+aR1FzsBq/ZjrxWiXymZldeOGFTuyRRx6JfF5HA78wAwAAACFYMAMAAAAhWDADAAAAIVgwAwAAACFYMAMAAAAhSuUuGaokpG+XDJVx6svQX7FihROrW7euE/NlN6vsUrUjhi+7NWp/H3UNfCUt1c4HvlKbitr5AKVTLGNQWb16tRNr1KiRE9u0aZPsr8rqzpkzR7ZV5bVVGXZVvtdMZ2P77leVOa5et1evXrL/Bx98IOMou9Qc6iv1q3aj8O2cosa12r3GR41L39yudnVR8/2uXbsiH//HH3+M3LasiOWzVh5++OHIbQcOHOjEmjVrJtuq9Yn6rHznqspoq50zfONH9a9Xr55sq15X9fd932RlZTmxV155Rbb96quvZPxgsdxXsayvouAXZgAAACAEC2YAAAAgBAtmAAAAIAQLZgAAACBEmUn68z1UrpL+fA96q/KfTZs2dWJbt26V/VXCkUoCUQ/Km+kkhFhKY6vylevWrZP9Z8+e7cSaN28u26pkLl+SJcqfqCXbfWNVjcs2bdrItu+//74TmzZtmhO77bbbZH+VCKNKu5vp+1UljKiSrGYk/ZVHsSR9qe8hXwnhvXv3OjE11nzlrlVb33deLK8ble97pCwr7oSvML6NBqK2VePHV9pcjYukpCQn5kv6U/03bNgg26pkRHWsqlWryv6+1y0KtXmCmf/7qTixKgIAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABClMqkP1VlzvdAt0rs2bJli2y7atUqJ6aSBn3HippE4OuvEk5ieVBdJXv4klDUw/adO3eWbVWlN9+D9Sh9ola08n2mKkFPJZz4EqZUlTNVZc/MLD093Ym1bNnSialqZma6opnvfalEKJVw40tYQcXWrVs3J+ZL7lL3S/Xq1Z1YtWrVZH+VuOpL+oslITeq/Pz8IvWv6NT18303q7lRzWG1a9eW/X0VVw/mm6/VGPQljar1lUom9G0S4EtcjEqteXzv62gkefILMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCCBTMAAAAQolTukqEyM1XpSDOzunXrOrFFixbJtiq7U+2S4csYVVmYKpM5lvKnsWR2qra+/tu2bXNiqqSlmb62aucDlE5Ry/3ed999Ml6nTh0npkrl+krGq3HtK1fdunVrJ9auXTsnpsav73V9u1ysXLnSiams7aKWFUbZpkpgm5l1797diamdlszMUlNTnZj6HvPtnKDuLd8OA2pHBXUPxrL7i9p9pqw7mqWx1c4Vvu9QteZQaxPfHKo+fzWHqTFppseaGqtm/p1aDuZbW/h2LCuKWMrbFzd+YQYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABClJlsF18ChEpsUGWhzcwqV67sxGJJDFAP1vsezFdUYoY6JzP9YL9KFvAldqgkBF8J4V27djkxVZ4cZVu/fv1kXCVmqFKnvrE2c+ZMJ7Zx40bZtkWLFk5MlRv2JawovoRgdb80b97cid1///2Rj4WjJ2qStGrna6v89a9/lfFY5ntVBluVQPaVsI4ledxXdv5gKpHM56STTpLxb775JvJrVGTq+9b3+UX9XHzf11HLoPuOo8aar61KBlT3gO9e861vyip+YQYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQpTKXTJUmUVfJrTKwvTtklGtWjUnpjKOfaUXVXapivn6q6xZXyasorJTfaVW165d68Tq1asn26r3EEtZVRwdsewGcO655zqxrKws2V+VkFb3lbp/zMzeffddJzZ//nzZ9oorrnBiXbp0cWK+3QjU7h2+rPH09HQntmTJEif2yiuvyP4VWVF3njhS1OcfS6nca6+91on98Y9/lG2//fZbJ1arVi3ZVl0XFfPtcKHivpLdarzHsnvI6tWrndhpp50m244ePVrGcWhqrJrpz0p9j/vuNbWjhdrNwrdLh7pffG2VqOug8ohfmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQpTLpLyMjw4nFkgS0cOFC2VYlLakH4FVJXd85qIf1Y0lC8b0v9bqqBLAvOU8lXfnOS11DlUSAkhVLwtXEiROd2HfffSfbqs+/fv36kV7TTCf9HX/88bKtel2V+Oord634kptUcszy5csjv25547tOsSQeR00481FjzXdeRT1W3759ndj111/vxM455xzZ/9lnn3Vi+fn5sq1K2lNj2Jf0pxJUfZ+LuoaqNLcvIXzbtm1OTJWsR3Rbt251YnXr1pVtMzMzI7XdvHmz7K8S9NQ6IGoJbTOzNm3ayLh6Xyoh3JegWtQk4ZJOMj4YvzADAAAAIVgwAwAAACFYMAMAAAAhWDADAAAAIcpM0p/v4e/WrVs7sf/85z+y7fnnnx/p+LEkW6gH8H1Vb2KpUqUerFf9a9asKfuraoe+81LJIaraIoqfrxpULImjmzZtcmKqStm//vUv2f/ee+91YjNmzHBiu3btkv2HDRvmxLp16ybbquQS9bq+ylPqesVyv7333nuybdT+sXwupY1vDj2aVbqOxPUbPHiwjN98881OrF27dk7sT3/6k+yfkpLixBYtWiTbqu8slfSn2pnpxEdfQrhKXlexPXv2yP7qM6hRo4Zsi8J8CaoXX3yxE5syZYpsq+Y29bo7duyQ/dWmBA0bNnRiGzdulP23b9/uxHzJrCqZUI1LX4KhSv6ePHmybFsW5lZ+YQYAAABCsGAGAAAAQrBgBgAAAEKwYAYAAABCsGAGAAAAQpTKXTLUDg2+DG9V/taXHZqamhrp+LGUkI6lndp9w9fWlyF9MF9285YtW5yYKolqpstg+zKsUZgva1plQqtxFUv50lGjRsm4GgNq95SpU6fK/moMPvroo05MZVebmV166aVOzFdaXV0DdV/6SlirHV18n4EqQ/z+++/LthVZ7dq1nZhv/lHzypHSpUsXJ3bLLbc4sUaNGsn+Dz/8sBO7++67nZgql21mtn79eifWtGlT2VbtNKLKBfvuC3Vv+XYqUjsXqO9H37HUfeEro11RqDlEXVPf7j/KkiVLZPzMM890YitWrHBieXl5sn9WVpYTU+fvu1fVfOv7/NU6QK251K5cZmb169d3YmrnDDOzr776SsZLE35hBgAAAEKwYAYAAABCsGAGAAAAQrBgBgAAAEKUyqQ/lSyhSkWbma1atSry69apU8eJqWQNXyJWLAlaikp48iUYqoQDlYijEkDMdILfypUrZVuVMOC73ijMl4waNWlTJVyZ6XK/w4cPl21VqdG//OUvTqxt27ay/9atW53YlVde6cTWrl0r+2/evNmJ+RJs09PTnZgqy6oSk8z03OAr2a3uge+++062VcpCqdZYqBLmZma//e1vndjixYtlW1UuWs2LDRo0kP1VCefs7GzZVo0hlbSpysCbmd1xxx2Rzss3Lyrq/H1xlUzrS7xWbX1zyJo1a5yY736JypcgWFH45vGDNWnSRMbVZ+L7/GrVquXE1DrGtyFATk6OE1Nl2NW9aqaT9nzUvamSYX1zsEo89CXOkvQHAAAAlHEsmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQpXKXDLVDgy+Ld/78+ZFfV5ULVtmdqoS1md5NQmWn+rLr1fvylaRUx1Kv6+uv2s6dO1e2rV69uhNTOycgurPPPtuJpaWlOTFf1rUqwfrNN9/Itq1atXJivXr1cmLr1q2T/X/88UcnprK+fbvEnHfeeU7Md7/u2LHDiamywG3atJH9ValWtfuNmdkrr7wi4xXVddddJ+Nq5wg1V5rpHU02bdrkxHxjVX2uvs9JlXxX5bI7deok+6udI9RuBL6dL9SOLL7y8AsXLnRiqrSxbzcGdSw11s30Lgdq5wXfzgWqbXnbEeZIyczMlHH1WasduMz0zkjt2rVzYp9//rnsX69ePSemdl/xzfdqzaDGn5lZ586dnZhac/l2H8rIyHBi6vvKzKxSJXc56ruGJYVfmAEAAIAQLJgBAACAECyYAQAAgBAsmAEAAIAQpTLpTyUM+RLxZs2aFfl1VWlglbDiS5ZQpSqjltQ004l8KhaL7t27y7gqma2Su8x0Ig2lsaOZM2eOjG/cuNGJqSQmXyKdSuxISkqSbX1JSwfLysqS8Q0bNjixli1bOjFfCWN1b/qSo9S4atSokRNTiUlmZj179nRixx57rGyrSiMrKtnErPQlnBTVF198IeOqBLX6/M10Ip36rFu0aCH7q2t9+umny7YqOUmdl68stJoD1XeLbw5W86WvtLUaw+q+VPeaWfRzNdMJmao8/YoVK2R/leB31113ybZlmfpcY/m+Vp+Jbw6eOXOmE/N9fmq+zM3NdWJqQwEzs8TERCcWy+YF6vP3vS9VXlvd7771grqH1Vg1098vixYtkm2Von7eUfALMwAAABCCBTMAAAAQggUzAAAAEIIFMwAAABCiVCb9qQe1fZWIfBWllMmTJzsx9VD6Tz/9JPurpCn1YL3vXGN5AF1VWlNJCC+++KLsrxJhFi9eLNt27drViVH5ydW+fXsnlpOTI9uqa636b9myRfZXlZN8CUe+5J6DHX/88TLevHlzJ6aqifnGrxorvmRGVVXyjTfecGIqGdfM7LXXXosUi0V5S+7zueqqq/7/9u7XJbIwCuP42SZoMYhlUINJxWJxiggGu8lmUTRYBLEoEycIJpPRZvRPsAgaBUHE4A8MKoIgmN28e55z9r07q+s43088vHfmzsydmZcLzzmyrn5XosDkysqKq6nQoHpMMz29LgoYqt9m9VlFoU11varAkQpzm+mQeERdw+o7EL3Wy8tLV4umyqlApQp9nZ6eyuNVIHlvb0+ubWfq868S8FVT6qKGAGraqPoNNdPv/8DAQPFzqcmcqhZN9lXfq2hicF9fn6up77CaXhiJAuEq6K5Cf1FI918H/BTuMAMAAAAJNswAAABAgg0zAAAAkGDDDAAAACTYMAMAAACJL9klQ3UDUGlNM7Pr6+vix200Gn99Tt9BNGZSJYSjhG8n29racrWom4jqiKHWRslelXC+urqSa1Wnllqt5mpR9xeVelajUqPOF+p1RaOtHx8fXW1xcVGuVVSau0pXmug1fDdRklxRHXU2NjbkWlWfn593tfX1dXn8xMRE8Xmpz6/K6yoVdWTZ2dlxte3tbbn26enJ1ZaXl11tbm5OHt/f3+9qagS2mdnh4aGrqY4aY2Nj8vjd3V1Z7wRVOuKMj4+7WtSpSHV+iEZbq+tNdUnp7u6Wx5+dnbma+q5Eo7FVp5DouW5ublxNdfBS47rN9PsV/eepLmTKZ3TDiHCHGQAAAEiwYQYAAAASbJgBAACABBtmAAAAIPElQ38qmKNG6pqZ3d/fFz+uGoHa7iOgq4yJjEJjKlxS5X3tFMfHx642Ozsr16oQhfqs1EhTM7PV1dXi81Kf9evrq6tFo1ZVkE5dE+oxzXSQ5uXlRa6dmZlxtefnZ7lWiYI0+FWVYIy6Lqscf3BwUFSLTE9Py7oKCEZBOEWNjD86OnK1aIRwq9S46ZOTE7lWhaNUGNPMrKenx9VU6Ozh4eFPp/ittXpdq+tPjSU3079LFxcXcq0agz04OOhqaty2mdno6Kirqf1RFHBUa6PAnfpvmJqaKn6urq4uV4u+w9F/xlfCHWYAAAAgwYYZAAAASLBhBgAAABJsmAEAAIAEG2YAAAAg8eO9MDb6ESNJI2tra642MjIi1y4tLRU/bqd3yYjs7++7muqSsbm5WX5iFfzPUZetXtcq3WxmNjk56WrDw8NFNTOz3t5eV4vGl0Yjr38XdZh4e3tzNZXwjkarq+4hd3d3RedUVavJ98/Uztc1EOnk63poaEjWVeeS8/NzubZWq7nawsKCqzWbTXm8ev/VGO/b21t5fL1eLzonM/0a1GjsaLy86oih/m/MqnVL+ggl1zV3mAEAAIAEG2YAAAAgwYYZAAAASLBhBgAAABLFoT8AAACgE3GHGQAAAEiwYQYAAAASbJgBAACABBtmAAAAIMGGGQAAAEiwYQYAAAASbJgBAACABBtmAAAAIMGGGQAAAEj8BN7bHvUDFPWfAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Since , we cannot load all the 70k images once in the modle there is where the concept of dataloader cames and play inn"
+      ],
+      "metadata": {
+        "id": "bfzUa5Lgjxms"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from torch.utils.data import DataLoader\n",
+        "\n",
+        "BATCH_SIZE = 32\n",
+        "\n",
+        "train_dataloader = DataLoader(train_data,\n",
+        "                              batch_size=BATCH_SIZE,\n",
+        "                              shuffle=True)\n",
+        "\n",
+        "test_dataloader = DataLoader(test_data,\n",
+        "                             batch_size=BATCH_SIZE,\n",
+        "                             shuffle=False)\n"
+      ],
+      "metadata": {
+        "id": "DSPh1XSukSpL"
+      },
+      "execution_count": 38,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "With the help of this datloder we are going to build up our baseline model with the two linearty. Later its accuracy will be capared with others ."
+      ],
+      "metadata": {
+        "id": "F_m_C5p4kzeU"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "from torch import nn\n",
+        "from torch.utils.data import DataLoader\n",
+        "from torchvision import datasets\n",
+        "from torchvision.transforms import ToTensor\n",
+        "\n",
+        "# 1. Load FashionMNIST (same as earlier steps)\n",
+        "train_data = datasets.FashionMNIST(\n",
+        "    root=\"data\",\n",
+        "    train=True,\n",
+        "    download=True,\n",
+        "    transform=ToTensor()\n",
+        ")\n",
+        "\n",
+        "test_data = datasets.FashionMNIST(\n",
+        "    root=\"data\",\n",
+        "    train=False,\n",
+        "    download=True,\n",
+        "    transform=ToTensor()\n",
+        ")\n",
+        "\n",
+        "# 2. Create DataLoaders\n",
+        "BATCH_SIZE = 32\n",
+        "\n",
+        "train_dataloader = DataLoader(train_data,\n",
+        "                              batch_size=BATCH_SIZE,\n",
+        "                              shuffle=True)\n",
+        "\n",
+        "test_dataloader = DataLoader(test_data,\n",
+        "                             batch_size=BATCH_SIZE,\n",
+        "                             shuffle=False)\n",
+        "\n",
+        "# 3. Define baseline model (Model 0)\n",
+        "class FashionMNISTModelV0(nn.Module):\n",
+        "    def __init__(self, input_shape: int, hidden_units: int, output_shape: int):\n",
+        "        super().__init__()\n",
+        "        self.flatten = nn.Flatten()  # [1, 28, 28] -> [784]\n",
+        "        self.layers = nn.Sequential(\n",
+        "            nn.Linear(input_shape, hidden_units),  # [784] -> [hidden_units]\n",
+        "            nn.ReLU(),                             # non-linearity\n",
+        "            nn.Linear(hidden_units, output_shape)  # [hidden_units] -> [10]\n",
+        "        )\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        x = self.flatten(x)      # make image 1D\n",
+        "        logits = self.layers(x)  # pass through linear layers\n",
+        "        return logits\n",
+        "\n",
+        "# 4. Instantiate model, loss, optimizer\n",
+        "input_shape = 28 * 28\n",
+        "hidden_units = 10\n",
+        "output_shape = len(train_data.classes)  # 10\n",
+        "\n",
+        "model_0 = FashionMNISTModelV0(\n",
+        "    input_shape=input_shape,\n",
+        "    hidden_units=hidden_units,\n",
+        "    output_shape=output_shape\n",
+        ")\n",
+        "\n",
+        "loss_fn = nn.CrossEntropyLoss()\n",
+        "optimizer = torch.optim.SGD(model_0.parameters(), lr=0.1)\n",
+        "\n",
+        "# 5. One simple training + testing pass (1 epoch, minimal)\n",
+        "EPOCHS = 1\n",
+        "\n",
+        "for epoch in range(EPOCHS):\n",
+        "    # ----- Train -----\n",
+        "    model_0.train()\n",
+        "    train_loss = 0\n",
+        "    for X, y in train_dataloader:\n",
+        "        # forward pass\n",
+        "        y_pred = model_0(X)\n",
+        "\n",
+        "        # loss\n",
+        "        loss = loss_fn(y_pred, y)\n",
+        "        train_loss += loss.item()\n",
+        "\n",
+        "        # backward + update\n",
+        "        optimizer.zero_grad()\n",
+        "        loss.backward()\n",
+        "        optimizer.step()\n",
+        "\n",
+        "    # ----- Test -----\n",
+        "    model_0.eval()\n",
+        "    test_loss = 0\n",
+        "    correct = 0\n",
+        "    total = 0\n",
+        "\n",
+        "    with torch.inference_mode():\n",
+        "        for X_test, y_test in test_dataloader:\n",
+        "            test_pred = model_0(X_test)\n",
+        "            loss = loss_fn(test_pred, y_test)\n",
+        "            test_loss += loss.item()\n",
+        "\n",
+        "            # predictions\n",
+        "            preds = test_pred.argmax(dim=1)\n",
+        "            correct += (preds == y_test).sum().item()\n",
+        "            total += y_test.size(0)\n",
+        "\n",
+        "    print(f\"Epoch: {epoch+1}\")\n",
+        "    print(f\"Train loss: {train_loss/len(train_dataloader):.4f}\")\n",
+        "    print(f\"Test loss: {test_loss/len(test_dataloader):.4f}\")\n",
+        "    print(f\"Test accuracy: {correct/total:.4f}\")\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "psjplVlkk9_L",
+        "outputId": "fc98eb3b-405f-4782-bdee-a3cdef1e7deb"
+      },
+      "execution_count": 39,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch: 1\n",
+            "Train loss: 0.6376\n",
+            "Test loss: 0.5000\n",
+            "Test accuracy: 0.8226\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "test loss of 0.5 and test acuracy . Lets visualize the prediction of some five images using it"
+      ],
+      "metadata": {
+        "id": "4s42dINwlWTP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "model_0.eval()\n",
+        "with torch.inference_mode():\n",
+        "    X_sample, y_sample = next(iter(test_dataloader))   # one batch from test set\n",
+        "    logits  = model_0(X_sample)                        # [32, 10]\n",
+        "    preds   = logits.argmax(dim=1)                     # [32]\n",
+        "\n",
+        "# Show first 5 images, true vs predicted labels\n",
+        "for i in range(5):\n",
+        "    img = X_sample[i].squeeze()\n",
+        "    true_label = class_names[y_sample[i]]\n",
+        "    pred_label = class_names[preds[i]]\n",
+        "\n",
+        "    plt.figure()\n",
+        "    plt.imshow(img, cmap=\"gray\")\n",
+        "    plt.axis(False)\n",
+        "    plt.title(f\"True: {true_label} | Pred: {pred_label}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "ufWAKShrleQi",
+        "outputId": "b966b0a2-fda4-40ea-ffbb-0fdd52e8fca3"
+      },
+      "execution_count": 40,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGbCAYAAAAr/4yjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAHdNJREFUeJzt3Hl0VOX5wPFnkpBJJiELWQhETICwC4W6gCKrmCBoRUSUo2zWBUWUHq0iHitrD0EtFpGtpVLWVtywHjiCC9QeCtSKUAQULKCsoQoICSSEPL8//OWRyYQw75Wd7+cc/sjNfWbu3Ezmm0kur09VVQAAEJGIc30AAIDzB1EAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFG4iC1btkx8Pp+8/vrrVe43c+ZM8fl8sm3bttNyv+W398knn5yW2zuTys/R6XrsZ9Lp/jqdLj6fTx555JEq99m2bZv4fD6ZOXPmabnP8tt74YUXTsvt4UcXTRR8Pl9Y/5YtW3auD7VKBw4ckJiYGPH5fLJx48ZzfTgXnEWLFsmIESPOyG1nZ2cHPZfS09OlXbt28tZbb52R+zuTrrnmGvH5fDJlypRzfSgXnA0bNsiIESPOuzifLlHn+gBOl9mzZwd9PGvWLFm6dGnI9iZNmpzNw3K2YMEC8fl8kpGRIXPnzpUxY8ac60O6oCxatEheeeWVMxaGli1byuOPPy4iIrt27ZJp06ZJz549ZcqUKTJo0KAzcp+n2+bNm+Vf//qXZGdny9y5c+Whhx4614d0QdmwYYOMHDlSOnbsKNnZ2ef6cE67iyYK99xzT9DHK1eulKVLl4Zsr6ioqEgCgcCZPDQnc+bMkW7duklWVpbMmzePKJxnMjMzg55T/fr1k5ycHJkwYcJJo1BaWiplZWUSHR19tg6zSnPmzJH09HR58cUXpVevXrJt27aL8sUN3lw0vz4KR8eOHeWKK66Qf//739K+fXsJBAIyfPhwEfnh10+V/XSZnZ0tAwYMCNp24MABGTp0qNSpU0f8fr/k5ORIfn6+lJWVBe23e/du2bRpkxw7diys4/v666/l448/lrvuukvuuusu2bp1q6xYseKkj2PDhg3SqVMnCQQCkpmZKePHjz/lfRQXF8vNN98siYmJld72iRYvXizt2rWTuLg4qV69unTv3l0+//zzsB6LyA/BffDBByUlJUUSEhKkX79+sn///pD9Jk+eLM2aNRO/3y+1a9eWwYMHy4EDB0L2W7BggVx55ZUSGxsrqampcs8998jOnTvt8wMGDJBXXnlFRIJ/nXgmZWRkSJMmTWTr1q0iEvy77pdeeknq168vfr9fNmzYICIimzZtkl69ekmNGjUkJiZGrrrqKnnnnXdCbvfzzz+Xzp07S2xsrFx22WUyZsyYkOeXiMjBgwdl06ZNcvDgwbCPed68edKrVy97HsybNy9knxEjRojP55MtW7bIgAEDJCkpSRITE2XgwIFSVFR0yvsYM2aMREREyMsvv1zlfuGej6pMmDBBsrKyJDY2Vjp06CDr168P2efDDz+053JSUpLceuutlf56ds2aNXLTTTdJQkKCxMfHyw033CArV660z8+cOVPuuOMOERHp1KnTBfNraSd6kRo8eLBWfHgdOnTQjIwMTUtL0yFDhui0adP07bffVlVVEdHnnnsu5HaysrK0f//+9nFhYaG2aNFCU1JSdPjw4Tp16lTt16+f+nw+feyxx4Jm+/fvryKiW7duDeuYx40bp/Hx8VpUVKSqqvXr19eHH344ZL8OHTpo7dq1tU6dOvrYY4/p5MmTtXPnzioiumjRItvvo48+UhHRBQsWqKpqUVGR3njjjZqcnKyrV6+2/V599dWQ45w1a5b6fD7t2rWrvvzyy5qfn6/Z2dmalJR0ysdTfnvNmzfXdu3a6cSJE3Xw4MEaERGh7du317KyMtv3ueeeUxHRLl266Msvv6yPPPKIRkZG6tVXX60lJSUht3n11VfrhAkTdNiwYRobG6vZ2dm6f/9+VVVdsWKF3njjjSoiOnv2bPtXlfJzFM7XKCsrS7t37x60raSkRGvWrKkZGRmqqrp161YVEW3atKnWq1dPx40bpxMmTNDt27fr+vXrNTExUZs2bar5+fk6adIkbd++vfp8Pn3zzTftNnfv3q1paWmanJysI0aM0Oeff14bNGigLVq0CDnW8vPy6quvnvL4VVVXrlypIqIff/yxqqree++92rRp05D9yr8urVq10p49e+rkyZP1vvvuUxHRJ598MmhfEdHBgwfbx88884z6fD6dPn26bSs/LyceZ7jnozLlt9e8eXPNzs7W/Px8HTlypNaoUUPT0tJ0z549tu/SpUs1KipKGzZsqOPHj9eRI0dqamqqJicnB53L9evXa1xcnNaqVUtHjx6t48aN07p166rf79eVK1eqqupXX32ljz76qIqIDh8+3J5jJ97fhe6Si4KI6NSpU0P2DzcKo0eP1ri4OP3yyy+D9hs2bJhGRkbq119/bdtco9C8eXO9++677ePhw4dramqqHjt2rNLHMWvWLNtWXFysGRkZevvtt9u2E6Nw6NAh7dChg6ampuqaNWuCbq9iFA4dOqRJSUl6//33B+23Z88eTUxMDNleUfntXXnllUEv7OPHj1cR0YULF6qqakFBgUZHR2tubq4eP37c9ps0aZKKiP7pT39S1R9eeNPT0/WKK67QI0eO2H7vvvuuioj+5je/sW2Vfd2r4hqF3Nxc3bdvn+7bt0/Xrl2rd911l4qIDhkyRFV/fLFKSEjQgoKCoPkbbrhBmzdvrkePHrVtZWVlet1112mDBg1s29ChQ1VEdNWqVbatoKBAExMTf3IUHnnkEa1Tp46FecmSJSoiIc+J8ijce++9Qdtvu+02TUlJCdp2YhQef/xxjYiI0JkzZwbtU1kUwj0flSm/vdjYWN2xY4dtX7VqlYqI/upXv7JtLVu21PT0dP32229t29q1azUiIkL79etn23r06KHR0dH61Vdf2bZdu3Zp9erVtX379rZtwYIFKiL60UcfVXmMF6pLLgp+v1+Li4tD9g83Ci1atNCuXbvaC0P5v/fff19FROfMmePpeNeuXasiou+++65t+89//hOyrfxxxMfHB/3Erar6i1/8Qlu1amUfl7/g/fGPf9Rrr71Wa9asqevXrw+574pRePPNN1VE9MMPPwx5nLm5uZqTk1PlYym/vWnTpgVtP3TokEZFRemDDz6oqqrz5s0LeXej+kPgEhISLHArVqxQEdHJkyeH3Ffjxo31yiuvtI/PdBREJOhfZGSk9u3b197dlb9YDRw4MGj222+/VZ/Pp6NHjw45pyNHjlQRsRe3hg0baps2bULu/+GHH3b6IaOiY8eOaVpamj7xxBO2rbS0VNPT04O2qf4YhRPfUaqq/u53v1MR0YMHD9o2EdGHH35YBw8erFFRUTpv3ryQ+64YBZfzUZny2+vTp0/I51q3bq2NGjVS1R9e1Ct7d6OqmpeXp6mpqXYeAoGA9u7dO2S/Bx98UCMiIuwxX+xRuGj+0ByuzMzMn/QHv82bN8u6deskLS2t0s8XFBR4ut05c+ZIXFyc1KtXT7Zs2SIiIjExMXaFSPfu3YP2v+yyy0J+X56cnCzr1q0Lue2hQ4fK0aNHZc2aNdKsWbNTHsvmzZtFRKRz586Vfj4hISGsx9SgQYOgj+Pj46VWrVp2Kd/27dtFRKRRo0ZB+0VHR0u9evXs8yfbT0SkcePG8o9//COs4zkdWrduLWPGjBGfzyeBQECaNGkiSUlJIfvVrVs36OMtW7aIqsqzzz4rzz77bKW3XVBQIJmZmbJ9+3Zp3bp1yOcre/wulixZIvv27ZNrrrnGnmMiP/xufP78+ZKfny8REcF/Zrz88suDPk5OThYRkf379wc9D2bNmiWHDx+WKVOmSJ8+fU55LC7noyoVn2MiIg0bNpTXXntNRKp+7jRp0kTee+89KSwslEOHDklRUdFJ9ysrK5NvvvkmrO+fC90lF4XY2Fin/Y8fPx70cVlZmdx4443y5JNPVrp/w4YNnY9JVWX+/PlSWFgoTZs2Dfl8QUGBHD58WOLj421bZGTkSW+roltvvVX+8pe/yLhx42TWrFkh3/gVlf9Bc/bs2ZKRkRHy+aioS+5pY1JTU6VLly6n3K/i86z8nD7xxBOSl5dX6UxOTs5PP8AqzJ07V0REevfuXennly9fLp06dQraFu7zrG3btvLZZ5/JpEmTpHfv3lKjRo0qj+V8OB+o3KX73V1BcnJyyBUvJSUlsnv37qBt9evXl8OHD4f1whCu5cuXy44dO2TUqFEh/49i//798sADD8jbb799ystrT6ZHjx6Sm5srAwYMkOrVq5/yPyzVr19fRETS09N/0uPcvHlz0IvM4cOHZffu3dKtWzcREcnKyhIRkS+++ELq1atn+5WUlMjWrVvtvk/cr+K7ly+++MI+LyJn/Gojr8ofX7Vq1U55TrOysuzd2om++OILz/dfWFgoCxculDvvvFN69eoV8vlHH31U5s6dGxKFcOXk5Mj48eOlY8eO0rVrV/nggw+kevXqJ93f5XxUpbLz9OWXX9oltic+dyratGmTpKamSlxcnMTExEggEDjpfhEREVKnTh0ROX+fY6fLJXVJalXq168vf//734O2TZ8+PeSdQu/eveWf//ynvPfeeyG3ceDAASktLbWPw70ktfxXR7/+9a+lV69eQf/uv/9+adCggf2U51W/fv1k4sSJMnXqVHnqqaeq3DcvL08SEhLkt7/9baXHvm/fvrDuc/r06UHzU6ZMkdLSUrnppptERKRLly4SHR0tEydODPrJc8aMGXLw4EH7ldlVV10l6enpMnXqVCkuLrb9Fi9eLBs3bgz61VpcXJyISKWXtJ5L6enp0rFjR5k2bVrIDxoiwee0W7dusnLlSlm9enXQ5yt7DoR7Sepbb70lhYWFMnjw4JDnWPnlqW+88UbQ+XXVokULWbRokWzcuFFuueUWOXLkyEn3dTkfVXn77beDLktevXq1rFq1yp5jtWrVkpYtW8qf//znoOfE+vXrZcmSJfYDSmRkpOTm5srChQuD/qfy3r17Zd68eXL99dfbr8vO1+fYaXMu/6BxJp3sD83NmjWrdP+pU6eqiGjPnj11ypQpOmjQIK1bt66mpqaGXJL685//XKOiovS+++7TKVOm6AsvvKD9+/fXuLg43bdvn+0bztVHR48e1aSkJO3Ro8dJ93n88cc1KipK9+7dW+Xj6N+/v2ZlZdnHFS9JVVUdO3asioiOHTvWtlV2SercuXM1IiJCr7jiCh0zZoxOmzZNn3nmGW3ZsmXQ5YeVqXhJavmlphEREXr99ddXeklqbm6uTpo0SYcMGVLlJamtW7fWl156SZ9++mkNBAJBl6Sqqr722msqItq3b1+dM2eOzp8/v8pj/amXpFZU/gfQ559/PuRzn3/+uSYnJ2tKSooOGzZMp0+frqNHj9Zu3bppixYtbL9du3ZpSkrKab0ktWvXrpqSkqKlpaWVfv5vf/ubioi+8cYbqvrj1+XE5/OJ93fiMUiFS1I/+OAD9fv92q1bN/saVnb1UbjnozKVXZI6atQorVGjhqakpOiuXbts3/JLUhs3bqzPP/+8jho1yi75/e9//2v7lV+SmpmZqWPHjtX8/HytV69e0CWpqj9cMhwZGalt2rTRmTNn6vz58+1782JAFP7f8ePH9amnntLU1FQNBAKal5enW7ZsCbn6SPWHq2iefvppzcnJ0ejoaE1NTdXrrrtOX3jhhaAXsnCi8MYbb6iI6IwZM066z7Jly1RE9Pe//32VjyOcKKiqPvnkkyoiOmnSJFWt/Bu9fD4vL08TExM1JiZG69evrwMGDNBPPvnkpMd64u0tX75cH3jgAU1OTtb4+Hi9++67gy4LLDdp0iRt3LixVqtWTWvWrKkPPfRQ0At9ub/+9a/aqlUr9fv9WqNGDb377rtDrlApLS3VIUOGaFpamvp8vlNeiXQ2o6D6w3Xu/fr104yMDK1WrZpmZmbqzTffrK+//nrQfuvWrdMOHTpoTEyMZmZm6ujRo3XGjBmeorB3716NiorSvn37nnSfoqIiDQQCetttt6nqT4uCqurChQs1KipK77zzTj1+/HilUXA5HxWdeJ5ffPFFrVOnjvr9fm3Xrp2uXbs2ZP/3339f27Ztq7GxsZqQkKC33HKLbtiwIWS/Tz/9VPPy8jQ+Pl4DgYB26tRJV6xYEbLfH/7wB61Xr55GRkZedFci+VQr+cskcIlYtmyZdOrUSbZu3cpSD4DwNwUAwAmIAgDAEAUAgOFvCgAAwzsFAIAhCgAAE/YyFxf7f+0GgItdOH8t4J0CAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAABN1rg8AwPklMjLSeaasrMx5RlWdZ7zy+/3OM8XFxc4zOTk5zjMiIlu2bPE0dybwTgEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGVVJxUfL5fGdlxsvqoJmZmc4zIiLXXnut88zixYudZwoLC51nzndeVjz14vbbb/c0l5+ff5qPxDveKQAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYFgQD/h/Xha386Jdu3ae5lq3bu08U7t2beeZiRMnOs+c79LT051n8vLynGe+//5755nzDe8UAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwLIiHi1JkZKTzTGlpqfPMVVdd5TzTpEkT5xkRkb179zrPNGjQwHnmrbfecp757rvvnGdiY2OdZ0REtm/f7jyTkpLiPJOQkOA8s2PHDueZ8w3vFAAAhigAAAxRAAAYogAAMEQBAGCIAgDAEAUAgCEKAABDFAAAhigAAAxRAAAYogAAMCyIh/NeRIT7zy5eFreLi4tznrnjjjucZ4qLi51nRERiYmKcZ6pXr+484/P5nGe8fI283I+ISLNmzZxnvvnmG+eZ/fv3O89ERV34L6m8UwAAGKIAADBEAQBgiAIAwBAFAIAhCgAAQxQAAIYoAAAMUQAAGKIAADBEAQBgiAIAwBAFAIC58Jf0uwB4WQ1SVT3dl5fVKr3cl5eZyMhI5xkRkePHj3uaczVo0CDnmT179jjPHD161HlGRCQ7O9t5xsvKqnv37nWe8fK1LSsrc54RESksLHSeKSkpcZ5JSEhwnvH7/c4zIt5W6PVyHsLBOwUAgCEKAABDFAAAhigAAAxRAAAYogAAMEQBAGCIAgDAEAUAgCEKAABDFAAAhigAAMwlvSDe2Vqozuvidl54XWTMlZcF0M7WwnYiIn369HGeycjIcJ759NNPnWeqVavmPCMikpSU5Dzz7bffOs989913zjOpqanOM9WrV3eeEfG+sKIrL4tLBgIBT/fVoEED55nPPvvM032dCu8UAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwl/SCeGdroTovC2t5mRHxtuicl/NwNhe3GzhwoPNMo0aNnGe++eYb5xkvC8F5WYhRRCQ2NtZ5ZufOnc4zXhaq87IQY1FRkfOMiEhMTIzzzNla/NKrvLw85xkWxAMAnHFEAQBgiAIAwBAFAIAhCgAAQxQAAIYoAAAMUQAAGKIAADBEAQBgiAIAwBAFAIA57xbE87oQnBdeFrzysrCWl8XCvMycTbVr13ae6dmzp6f78rIQ3ObNm51n4uPjnWf8fr/zTEpKivOMiEhJSYnzjJfneCAQcJ7xwuuiisXFxWflvgoLC51nvH7ftm3b1tPcmcA7BQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAATNgL4kVGRjrfuJdFqM73heC8LDDmRVpamqe5rKws55nGjRs7z9SqVct5xsuCbiIi33//vfNMUlKS80xCQoLzTLVq1ZxnvCyiJ+Lte8PL88HLYzpw4IDzzLFjx5xnRLydBy8LbR45csR5xsvrpIjIoUOHnGeaNWvm6b5OhXcKAABDFAAAhigAAAxRAAAYogAAMEQBAGCIAgDAEAUAgCEKAABDFAAAhigAAAxRAAAYogAAMGGvkuplxVMvatas6WnOy2qQcXFxZ2UmNjbWeaZu3brOMyIigUDAecbLapWHDx92nvGyUqWISGJiovOMl3NeWlrqPOPlfBcVFTnPiIgUFxc7z0RHRzvP7N6923nGy9fIy7kTEdm/f7/zTHx8vPNMcnKy80xhYaHzjIhIRkaG80xKSoqn+zoV3ikAAAxRAAAYogAAMEQBAGCIAgDAEAUAgCEKAABDFAAAhigAAAxRAAAYogAAMEQBAGDCXhDPiy5dujjP1K5d29N9eVnULT093XnGy6JuZWVlzjNeHo+IyKFDh5xnvCwW5mUBL5/P5zwjIuL3+51nvCya5uVr6+XcRUZGOs+IeFtszcvz4eDBg84zXr6XziYvzwcv37deFmIU8bZwoZcFHMPBOwUAgCEKAABDFAAAhigAAAxRAAAYogAAMEQBAGCIAgDAEAUAgCEKAABDFAAAhigAAEzYC+Ll5uY63/gvf/lL55lNmzY5z4iI7N6923nm+++/d57xsphZSUnJWbkfr7wsmuZlAa/jx487z4iIJCQkOM94WXzPy2JmXhZNq1atmvOMiLdFCGvWrOk806xZM+cZL4/pbD7HvSwmGAgEnGeOHj3qPCPi7fgKCgo83dep8E4BAGCIAgDAEAUAgCEKAABDFAAAhigAAAxRAAAYogAAMEQBAGCIAgDAEAUAgCEKAAAT9oJ4q1evdr7xNm3aOM80b97ceUZEpG3btp7mXJWWljrPeFlw7rvvvnOe8Tp38OBB5xkvC+J5WaRORCQlJcV5plGjRs4zXhZA87JYn6o6z4iI/OxnP3OeWbdunfPMtm3bnGe6dOniPOP3+51nRLyfP1devtd37tzp6b68LM4ZHx/v6b5OhXcKAABDFAAAhigAAAxRAAAYogAAMEQBAGCIAgDAEAUAgCEKAABDFAAAhigAAAxRAAAYn4a5upTXxczOFi+LQ7Vu3dp5pmHDhs4z1113nfNMenq684yItwXa4uLinGe8PB+8LmRWVlbmPONlYcBNmzY5zyxdutR5ZvHixc4zIiJHjx71NHc2vPPOO84zl19+uaf7+t///uc842VRSi8zXhbRExEpLi52nnniiSecZw4fPnzKfXinAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAHPRrJIKAKhaOC/3vFMAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAAEMUAACGKAAADFEAABiiAAAwRAEAYIgCAMAQBQCAIQoAABMV7o6qeiaPAwBwHuCdAgDAEAUAgCEKAABDFAAAhigAAAxRAAAYogAAMEQBAGCIAgDA/B9g05io7LEG1gAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGbCAYAAAAr/4yjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAGedJREFUeJzt3HtslfUdx/HP6aEXCi20tNByEUa5laIytgwZV+XSgHNMGSssjKKoGDCG3TAwI2zzxnSLyRYZZJugyWLn0I1IGHSksDBkiuBlKoINzGG4tbRAKb2dPvvD8J2HVu3vZzmt7fuV8Aft8+nzO09/7ec858A3FARBIAAAJMW19QIAAO0HpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAZ4sWLdKgQYOiPhYKhbRmzZo2Wc/ntWbNmiaPp71q7tq3pY62F0AptEgoFGrRn127drX1Upv18TXGxcWpb9++mjFjRrtdb3t17NixqGsZDod1zTXX6NZbb9Xrr7/e1strEfYCPkuXtl7AF8Gzzz4b9fdnnnlGxcXFTT6em5sby2U5mT59uhYuXKggCHT06FE99dRTuummm7R161bNnDmzrZf3hTJ//nzNmjVLkUhE7777rtatW6dt27Zp3759Gj16dFsv7zOxF/BpKIUWWLBgQdTf9+3bp+Li4iYfv1J1dbWSk5Ov5tJabNiwYVHrvfXWW3XdddfpySef7PC/CGpqapSQkKC4uNa5MR4zZkzUtRw/fry++c1vat26dVq/fn2zmYsXL6pbt26tcv7Pi73QenuhI+LKtJIpU6Zo1KhReu211zRp0iQlJydr1apVkj75NdZBgwZp0aJFUR+rrKzU8uXLNWDAACUmJmrIkCFau3atGhsbo447ceKEDh06pPr6eq/1XnvttcrIyNDRo0clSRs3blQoFNKxY8eijtu1a5f3S2MHDx7UzJkzlZqaqu7du2vq1Knat2+ffX7//v0KhULatGlTk+z27dsVCoX00ksv2cc+/PBD3XHHHerTp48SExOVl5enP/zhD82u97nnntMDDzygfv36KTk5WefPn3def0vddNNNktTkWu7evVtLly5V79691b9/fzt+27Ztmjhxorp166aUlBTdfPPNevvtt5t83b/85S8aNWqUkpKSNGrUKL344ovNnp+90H72QkfAnUIrKi8v18yZMzVv3jwtWLBAffr0ccpXV1dr8uTJ+vDDD7VkyRJdc8012rt3r1auXKkTJ07oySeftGNXrlypTZs26ejRo15vPFZUVKiiokJDhgxxzrbE22+/rYkTJyo1NVUrVqxQfHy81q9frylTpmj37t0aO3asvvrVr2rw4MH605/+pMLCwqh8UVGR0tLSlJ+fL0k6deqUbrjhBoVCId17773KzMzUtm3btHjxYp0/f17Lly+Pyv/85z9XQkKCfvSjH6m2tlYJCQlX5XFKUmlpqSSpV69eUR9funSpMjMz9eCDD+rixYuSPnopsrCwUPn5+Vq7dq2qq6u1bt06TZgwQQcPHrTv5Y4dOzRnzhyNHDlSjz76qMrLy3X77bdHlctl7IX2sxc6AkqhFZ08eVK//e1vtWTJEq/8r371K5WWlurgwYMaOnSoJGnJkiXq27evHn/8cf3whz/UgAEDvL52TU2NysrK7HXkVatWKRKJaO7cuV5f77M88MADqq+v1549ezR48GBJ0sKFCzV8+HCtWLFCu3fvliQVFBToiSeeUEVFhdLS0iRJdXV1evHFF3XbbbcpPj5ekvSTn/xEkUhEb731lv3yveeeezR//nytWbNGS5YsUdeuXaMe7/79+6M+1lqqq6tVVlamSCSiQ4cO6fvf/74kNbmW6enp2rlzp8LhsCSpqqpK9913n+68805t2LDBjissLNTw4cP1yCOP2Mfvv/9+9enTR3v27FGPHj0kSZMnT9aMGTM0cODAz7V+9gI+DS8ftaLExETdfvvt3vnnn39eEydOVFpamsrKyuzPtGnTFIlE9I9//MOO3bhxo4IgaPEzw9///vfKzMxU7969NXbsWP3zn//UD37wgybPqlpDJBLRjh079K1vfct+CUhSdna2vvvd72rPnj12C19QUKD6+nq98MILdtyOHTtUWVmpgoICSVIQBNq8ebNuueUWBUEQdW3y8/N17tw5HThwIGoNhYWFV+2XwOrVq5WZmamsrCxNmTJFpaWlWrt2rW677bao4+666y4rBEkqLi5WZWWl5s+fH/UYwuGwxo4dq5KSEkkfvRz0+uuvq7Cw0ApB+ugN4pEjRzZZD3uh7fZCR8SdQivq16/f57o1PXLkiN58801lZmY2+/nTp097f+3Zs2fr3nvvVSgUUkpKivLy8q7aG59nzpxRdXW1hg8f3uRzubm5amxs1H//+1/l5eXp+uuv14gRI1RUVKTFixdL+ujlgoyMDHut/syZM6qsrNSGDRuinmF/3JXX5ktf+lIrP6r/u/vuuzV37lzFxcWpZ8+eysvLU2JiYpPjrlzDkSNHJP3/PYgrpaamSpL+85//SJLdLX7c8OHDm/zSc8VewKehFFqR67ORSCQS9ffGxkZNnz5dK1asaPb4YcOGea+tf//+mjZt2id+PhQKtWiNV0NBQYEefvhhlZWVKSUlRVu2bNH8+fPVpctH2/Pym+wLFixo8nrzZdddd13U36/mM8OhQ4d+6rX8pDVcfhzPPvussrKymhx/+fFebewFfBpKIQbS0tJUWVkZ9bG6ujqdOHEi6mM5OTmqqqpq0S+c1nb5Ndwr13n5WauLzMxMJScn67333mvyuUOHDikuLi7qvZGCggL99Kc/1ebNm9WnTx+dP39e8+bNi/p6KSkpikQibXJtWktOTo4kqXfv3p/6OC6/Z3D5zuLjmrumrY290LnxnkIM5OTkRL0fIEkbNmxo8szrO9/5jl5++WVt3769ydeorKxUQ0OD/f3z/jPE5tYoKWqdkUjkE2/RP004HNaMGTP017/+NeqfNZ46dUp//OMfNWHCBHupRProZYRrr71WRUVFKioqUnZ2tiZNmhT19ebMmaPNmzfr3//+d5PznTlzxnmNbSE/P1+pqal65JFHmv2+XX4c2dnZGj16tDZt2qRz587Z54uLi/XOO+80ybEX/u+LshfaM+4UYuDOO+/UPffcozlz5mj69Ol64403tH37dmVkZEQd9+Mf/1hbtmzRN77xDS1atEhf+cpXdPHiRb311lv685//rGPHjlnm8/4zxCvl5eXphhtu0MqVK3X27Fmlp6frueeeiyoiFw899JCKi4s1YcIELV26VF26dNH69etVW1urX/ziF02OLygo0IMPPqikpCQtXry4yX8ueuyxx1RSUqKxY8fqrrvu0siRI3X27FkdOHBAf//733X27FmvdcZSamqq1q1bp+9973saM2aM5s2bp8zMTH3wwQfaunWrxo8fr9/85jeSpEcffVQ333yzJkyYoDvuuENnz57Vr3/9a+Xl5amqqirq67IXvnh7oV0L4GzZsmXBlZdu8uTJQV5eXrPHRyKR4P777w8yMjKC5OTkID8/P3j//feDgQMHBoWFhVHHXrhwIVi5cmUwZMiQICEhIcjIyAi+/vWvB0888URQV1dnxxUWFgaSgqNHj37meiUFy5Yt+8zjSktLg2nTpgWJiYlBnz59glWrVgXFxcWBpKCkpCTq3AMHDmxyjtWrV0d97MCBA0F+fn7QvXv3IDk5ObjxxhuDvXv3NnvuI0eOBJICScGePXuaPebUqVPBsmXLggEDBgTx8fFBVlZWMHXq1GDDhg12TElJSSApeP755z/z8V62evXqJo+nOUePHg0kBY8//vinHvf0008HkoJXX3212c+XlJQE+fn5QY8ePYKkpKQgJycnWLRoUbB///6o4zZv3hzk5uYGiYmJwciRI4MXXnih2WvPXmi9vYAgCAVBEMS8iYB2ZM2aNdq4cWOT/8ELdEa8pwAAMJQCAMBQCgAAw3sKAADDnQIAwFAKAADT4v+89knzUNA5paSkOGe+9rWveZ1r586dXrn2asyYMV65K//TWkscPnzY61zomFrybgF3CgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMC0eCAeYispKckrt3z5cufM/PnznTNpaWnOmczMTOeMJFVXVztn0tPTvc4VCzU1NV65S5cuOWcikYhzZvfu3c6Z3/3ud86Zv/3tb84ZXH3cKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAAATCoIgaNGBodDVXkuHtXbtWufM3Xff7XWulJQU54zPoDWfTH19vXNGkrp27eqciY+Pd86Ew2HnTF1dnXPGZ8CfJMXFuT+HS0xMdM74XG+fa/fyyy87ZyRp0qRJXjlILfl1z50CAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMAwJdWRz/TS9evXO2dOnjzpnJGkhoYGr1wsJCQkeOUikUgrr6R5LfxRiNLY2Oic8Zng6svnMfnsIZ/vUf/+/Z0zkrRt2zbnzC233OJ1ro6GKakAACeUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADAPxHJ06dco5k5SU5JypqqpyzkhSXJx7z2dlZXmdy1VFRYVXrra21jnjM9StW7duzhmf7215eblzRpLC4bBzxmdQXWJionPG5/dDXV2dc0aSunfv7pzJyclxzpSVlTln2jsG4gEAnFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwXdp6AV80PXr0cM74DHTzGWwn+Q23e+qpp5wzGzZscM689tprzhlJOnHihHOmf//+zpkLFy44Zz744APnTO/evZ0zkt8AuezsbOfM8ePHnTM+ezw1NdU5I0ldu3Z1zgwePNg50xEH4rUEdwoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAMBDPUWJionOmpqbGORMKhZwzvlatWuWcOXfunHMmHA47ZyQpOTnZObNr1y7nzI033uic8fHOO+945XJzc50zPkPn7rvvPufMQw895Jw5c+aMc0byGxY5fvx458wrr7zinOkIuFMAABhKAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAJhQEQdCiA2M4oC1WEhISnDO1tbXOmYqKCueM7/Xu2bOnc2bLli3OmdmzZztnWrjVWoXP9fvZz37mnDl//rxzpri42DkjSenp6c6Z06dPO2d89viRI0ecM+Xl5c4ZSUpJSXHOFBUVOWcWLlzonGnvWvIzyJ0CAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMB0aesFtKW+ffvG5DyNjY3Oma5du16FlTSvX79+MTuXj7lz58bkPM8884xzpqamxjkTDoedM5L0xhtvOGeys7OdM1VVVc6Z9m7o0KFtvYQvDO4UAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgOnUA/EyMjLaegmfKD4+3itXX1/vnPEZiBcXF7vnE7t3747JebZv3+6cGTx4sHOmvLzcOSNJs2bNcs6UlJQ4Z3wG7/kM0fPdQw0NDc6ZrKwsr3N1RtwpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAANOpB+L1798/JucJhUIxOY8kVVdXO2d8hoU1NjY6Z3yvw/Dhw50zjz32mHMmJyfHOePj3Xff9cqNGDHCOTNw4EDnzNKlS50z48aNc86cPXvWOSNJdXV1zhmfoY+dFXcKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwHTqgXiZmZkxOY/P8LhwOOx1Lp9cVVWVc+bhhx92zsTHxztnJGnGjBnOmeuvv945M2rUKOdMSkqKc8ZnsJ3kN+SvqKjIOTN69GjnjA/fPe7z8+S79zoj7hQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAKZTT0nNzs6OyXl8pjrGxfn1tc80yHPnzjlnVq1a5Zzx5bO+U6dOOWdGjhzpnPFx8uRJr5zPVN+amhqvc7kKgsA5E8spqT581heJRK7CSmKLOwUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgOvVAPJ8BY7FSV1fnldu5c6dzZtKkSc6Z48ePO2d8h4UlJCQ4Z7p0cd/aFy5ccM748BlaKPkN0ktKSnLO+FwHn6GFo0ePds5IUnl5uVfO1aBBg5wzpaWlrb+QGONOAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAAJhOPRCvZ8+eMTlP9+7dnTM+A+ckadOmTc6ZWbNmOWeqq6udM77i4tyfu4RCIeeMzxA9H0EQeOV8BuklJiY6ZxoaGpwzTz/9tHPGdyBerGRkZDhnGIgHAOhQKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAAJhOPRAvPT3dOeMzzCw5Odk5c+bMGeeMJFVUVHjlXNXV1TlnfAa6Sf4D5Nor38cTDodjcq6EhATnzL/+9S/njC+fx3Tp0iXnjM9QxY6AOwUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgOvVAvJ49ezpnamtrnTNJSUnOmaqqKueMJOXm5nrlXEUiEeeMz6A1X+15iJ7voDWfx+ST8fm5iOX19rl+cXHuz38zMzOdMx0BdwoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAANOpp6SGw2HnTKymQb733nteuZycnFZeSfN8roPPpErfc/lOIo0F3z3ks199pvr26NHDOXP69GnnjC+f6+CzHzIyMpwzHQF3CgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMB06oF4Xbq4P/xIJHIVVtLU4cOHvXKTJk1q5ZU0z+fa+fIZZuaTidWwQ99hfT4DBRsaGrzO5er48eMxyUhSr169vHKuUlJSYnKe9oY7BQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAGEoBAGA69UC8S5cuOWdiNRCvsbHRKzdixAjnTH19vXPGZzhbR+RzHXwH7/nsiVjt1yFDhjhnTp486XWurKws50xdXZ1zJjk52TnTEfCTDQAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAEynHojnMywsHA5fhZU01aWL37emV69ezpnq6mrnTKyuQyz5DqqLFZ+BeLH6Ps2ePds5c+zYMa9zffnLX3bO+Fy7tLQ050xHwJ0CAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMAzEc5SUlHQVVtJUbm6uVy4hIcE5U1tb65zxGdjnM5RMkkKhkFcuFufxycRy8F6sBuINGjTIOfPmm296nevb3/62V85VfHx8TM7T3nCnAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwnXpKal1dnXMmVhM709LSvHJdu3Z1zvhcB9+Jpz5idS6f6aWxykixm+J67tw558y4ceOcM4cPH3bO+PK55j4/Sx0BdwoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAdOqBePX19c6ZS5cuOWe6d+/unPnlL3/pnJGkqVOnOmd8Bn9FIhHnTCzFalBdrAYkSlI4HHbO+HyfUlNTnTO7du1yzrz00kvOGUlavXq1c8bnOiQkJDhnOgLuFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIDp1APxkpOTnTM+g7V8Bu/5DuMqKytzzgwdOtQ5U1pa6pyJi2vfz0FiNdzO9zyNjY3OmYaGBudMenq6c+b06dPOGZ+96svn53bgwIFXYSXtX/v+KQUAxBSlAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAA06kH4u3du9c5M27cOOdMTU2Nc+bw4cPOGUkaNmyYVw6ItcGDB3vlLly44JxJTEx0zrz66qvOmY6AOwUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgOnUU1JfeeUV50xycrJzpq6uzjnT2NjonAG+SOLj471yPhNPExISnDNVVVXOmY6AOwUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgOvVAvOPHjztnDhw44Jypqalxzly8eNE546tLF/dtEIlEnDOhUMg5g9jz+T757If333/fOSNJW7dudc706NHDObNv3z7nTEfAnQIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwoSAIgrZeBACgfeBOAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYP4H7k62DjQESAsAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGbCAYAAAAr/4yjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAFdVJREFUeJzt3XuQVnX9wPHPsrCLi7KSLKDmJRYvXDKyUhMUJ1EsskYpb2OBmpramH+kRtMojFPmVDNNMVI0eYmmnFG0HB1SmcF0UhvMzCwlJfAW3li5y944vz8cP79WQDhHfMDl9Zrhj332+TznPOewvPc8++yXuqIoigCAiOizo3cAgJ2HKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKLDLmzFjRhx44IE7eje2ybRp0z4w+8oHkyi8B3V1ddv05/7779/Ru9rDtGnTtmm/p02btqN3daeybNmyHsenvr4+9t9//zjllFPi8ccf39G7966cc7ZV3x29Ax9kc+fO7fHxr3/967jvvvs2uX3kyJG13K2tuvDCC2PixIn58dKlS+Oqq66KCy64II455pi8vbW1dUfs3k7vzDPPjM997nPR3d0dTz31VMyePTvmz58fjzzySIwdO3ZH795mOedss4Lt5pJLLim25ZCuW7euBnuz7RYtWlRERHHjjTe+6/3Wrl1bmx3azt58882iu7t7i5+/+uqriwMOOGCrj7N06dIiIoof/vCHPW6/8847i4goLrjggi3Obq9jN3Xq1G3a163Z1c85W+blo/fZcccdF2PGjIm//vWvceyxx0ZTU1N85zvfiYi3Xn6aMWPGJjMHHnjgJpfxK1eujMsuuyz222+/aGxsjBEjRsR1110XGzdu7HG/5cuXx9NPPx2dnZ3vab9vuummqKuriz/96U9x8cUXx5AhQ+LDH/5wfv7666+P0aNHR2NjY+yzzz5xySWXxMqVK7f6PCLeOibHHXdcj9t+9rOfxejRo6OpqSkGDRoUn/zkJ+O3v/1tj/u89NJLce6558bQoUOjsbExRo8eHTfccEOP+9x///1RV1cXt9xyS3z3u9+NfffdN5qammL16tXv6Xi8m8985jMR8dZ33xFbP3bz58+PY445JgYMGBB77LFHTJ48Of75z39u8ri///3vY8yYMdG/f/8YM2ZM3HHHHZvdvnNe+3Pem3n5qAZWrFgRn/3sZ+OMM86Is88+O4YOHVpqfv369TFhwoR46aWX4sILL4z9998/HnrooZg+fXosX748fvKTn+R9p0+fHjfffHMsXbp0u/xA8uKLL46Wlpa46qqrYt26dRHx1g9mZ86cGRMnToyLLrooFi9eHLNnz45FixbFn//85+jXr1+pbfzyl7+MSy+9NL70pS/FN7/5zdiwYUM88cQT8Ze//CXOOuusiIh45ZVX4qijjoq6urr4xje+ES0tLTF//vw477zzYvXq1XHZZZf1eMxrrrkmGhoa4lvf+la0t7dHQ0PDez4WW7JkyZKIiNhrr7163L65Yzd37tyYOnVqTJo0Ka677rpYv359zJ49O8aPHx9/+9vf8pzde++9MWXKlBg1alRce+21sWLFijjnnHN6/CP9Nuf8LbU8573ajr5U6U029/LRhAkTiogofv7zn29y/4gorr766k1uP+CAA4qpU6fmx9dcc00xYMCA4t///neP+337298u6uvri+effz5vmzp1ahERxdKlS7d5vzf3UsKNN95YREQxfvz4oqurK29/9dVXi4aGhuLEE0/scXk+a9asIiKKG264YYvP420TJkwoJkyYkB9/8YtfLEaPHv2u+3jeeecVe++9d/H666/3uP2MM84ompubi/Xr1xdFURQLFy4sIqIYPnx43rY1ZV8+mjlzZvHaa68VL7/8cnH//fcXH//4x4uIKObNm1cUxZaP3Zo1a4o999yzOP/883s87ssvv1w0Nzf3uH3s2LHF3nvvXaxcuTJvu/fee4uI2GRfnfPy55wt8/JRDTQ2NsY555xTef7WW2+NY445JgYNGhSvv/56/pk4cWJ0d3fHAw88kPe96aaboiiK7fa2xfPPPz/q6+vz4wULFkRHR0dcdtll0adPnx73GzhwYNx9992lt7HnnnvGiy++GIsWLdrs54uiiHnz5sXJJ58cRVH0OAaTJk2KVatWxWOPPdZjZurUqbHbbruV3pdtcfXVV0dLS0sMGzYsjjvuuFiyZElcd911ceqpp/a43zuP3X333RcrV66MM888s8dzqK+vjyOPPDIWLlwYEW+9HPT444/H1KlTo7m5OedPOOGEGDVq1Cb745y/5f0857sSLx/VwL777vueLmWfeeaZeOKJJ6KlpWWzn3/11VcrP/bWfOQjH+nx8XPPPRcREYccckiP2xsaGmL48OH5+TKuvPLKWLBgQRxxxBExYsSIOPHEE+Oss86KcePGRUTEa6+9FitXrow5c+bEnDlzNvsY7zwG79zv7emCCy6IL3/5y9GnT5/Yc88983X2d3rnPjzzzDMR8f8/g3ingQMHRsT/H+ODDjpok/sccsghm/xjuL0557s2UaiBst+9dHd39/h448aNccIJJ8QVV1yx2fsffPDBlfdta97Ld151dXWbvb27u7vHd6IjR46MxYsXx1133RV//OMfY968eXH99dfHVVddFTNnzswfpp999tkxderUzT7mYYcdtt32e2sOOuigHm/v3JJ37sPbz2Pu3LkxbNiwTe7ft+/O8eXonO/ado6/hbuoQYMGbfLujY6Ojli+fHmP21pbW2Pt2rXb9A/R++2AAw6IiIjFixfH8OHD8/aOjo5YunRpj33c3POLeOs7z/+djYgYMGBAnH766XH66adHR0dHnHrqqfG9730vpk+fHi0tLbHHHntEd3f3TnEMqnr7dwCGDBnyrs/j7WP89pXF/1q8ePH7s3PvwjnftfiZwg7U2tra4+cBERFz5szZ5ErhtNNOi4cffjjuueeeTR5j5cqV0dXVlR9vr7cnbsnEiROjoaEhfvrTn0ZRFHn7r371q1i1alVMnjw5b2ttbY1HHnkkOjo68ra77rorXnjhhR6PuWLFih4fNzQ0xKhRo6Ioiujs7Iz6+vqYMmVKzJs3L5588slN9um1117bXk/vfTVp0qQYOHBgfP/739/s+Xn7eey9994xduzYuPnmm2PVqlX5+fvuuy/+9a9/bTLnnLM9uVLYgb72ta/F17/+9ZgyZUqccMIJ8fe//z3uueeeGDx4cI/7XX755XHnnXfG5z//+Zg2bVp84hOfiHXr1sU//vGPuO2222LZsmU5s73fnvhOLS0tMX369Jg5c2acdNJJ8YUvfCEWL14c119/fXzqU5+Ks88+u8fzu+222+Kkk06K0047LZYsWRK/+c1vNvmt2RNPPDGGDRsW48aNi6FDh8ZTTz0Vs2bNismTJ8cee+wRERE/+MEPYuHChXHkkUfG+eefH6NGjYq2trZ47LHHYsGCBdHW1rbdn+v2NnDgwJg9e3Z85StficMPPzzOOOOMaGlpieeffz7uvvvuGDduXMyaNSsiIq699tqYPHlyjB8/Ps4999xoa2vL9/WvXbu2x+M652xXO+ptT73Rlt6SuqW33nV3dxdXXnllMXjw4KKpqamYNGlS8eyzz272bX1r1qwppk+fXowYMaJoaGgoBg8eXBx99NHFj370o6KjoyPvt73fnrho0aLNzsyaNas49NBDi379+hVDhw4tLrroouKNN97Y5H4//vGPi3333bdobGwsxo0bVzz66KObvD3xF7/4RXHssccWe+21V9HY2Fi0trYWl19+ebFq1aoej/XKK68Ul1xySbHffvsV/fr1K4YNG1Ycf/zxxZw5c/I+b7898dZbb93m5/9ef6P5nbZ27BYuXFhMmjSpaG5uLvr371+0trYW06ZNKx599NEe95s3b14xcuTIorGxsRg1alRx++23b/Y3mp3z8uecLasriv+5HoRd0IwZM+Kmm26KZcuW7ehdgR3OzxQASKIAQBIFAJKfKQCQXCkAkEQBgLTNv7y2pTVN2LlUOU9VXkE8/vjjS89ceumlpWciotL/f7y5tYW25tlnny09s/vuu5eeGTRoUOmZiKj0G8vvXFpiW5xyyimlZ/hg2JavdVcKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABI2/z/KVgQ74OhT5/ynd+4cWPpmQcffLD0zPjx40vP1NLq1atLzzQ1NZWe6dt3m9eh7GH9+vWlZ6rs38knn1x65q677io9Q+1ZEA+AUkQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACBVW5mLnVaVxe2qGDt2bOmZtra2Stt6/fXXS8/UaqG6FStWlJ7p6uoqPRNRbVHKESNGlJ459NBDS89YEK/3cKUAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkq6RSye677156pspqpxERAwcOLD3Tp0/573fa29tLz9TX15eeaWxsLD0TUW3/qthvv/1qsh12Tq4UAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQLIhHDB06tCbb6ezsrDRXFEXpmSoL4lVZ3K6rq6v0zMaNG0vPRFQ7DqtXry49M2TIkNIz9B6uFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkCyIR4wZM6Ym26m6IN5uu+1Weqa7u7smM1UW3quqyoJ97e3tpWcGDx5ceobew5UCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSBfGIww47rPRMR0dH6ZkNGzaUnomIaGpqKj3T2NhYembgwIGlZ9ra2krPVFVXV1d6pspxWLduXekZeg9XCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASBbEI4444ojSMxs3biw9U2Vhu4iIrq6u0jPNzc2lZx577LHSM2PHji0988Ybb5SeiYhob28vPVPlmL/wwgulZ+g9XCkAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACCJAgDJKqnEyJEjS890dnaWnqmysmpExO677156Zvny5aVnjjrqqNIzRVGUnunTp9r3YlXm+vYt/yXe1tZWeobew5UCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSBfGI5ubm0jNdXV2lZ2q5IN7tt99eaVu1UF9fX2muu7t7O+/J5jU0NNRkO+ycXCkAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACBZEI8YMmRI6Zn169eXnimKovRMVb/73e9qsp329vbSMx/60IcqbWvFihWV5spqamqqyXbYOblSACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAsiAelRZAW7t2bemZvn1r99dt4cKFNdnOww8/XHrm05/+dKVt1dfXV5orq1YL77FzcqUAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkq6RSM/369as019XVVXqmvb290rbKWrZsWemZ8ePHV9pWXV1dpbmyVq1aVZPtsHNypQBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgGRBPCopiqL0TNUF8ZYsWVJprhZefPHF0jN9+lT7XqzKMYeyXCkAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACBZEI9KOjs7S88MGDCg0raefPLJSnO1cPfdd5eeueKKKyptq+pCelCGv2UAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEgWxKOS+vr6mm1r6dKlNdtWWU888UTpmYaGhkrb6tevX6W5statW1eT7bBzcqUAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYBkQTzixRdfLD3T1NRUeqYoitIzERH//e9/K83VQldXV822VatFCC2It2tzpQBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACSrpBKvvPJK6ZnW1tbSM1VX+Tz44IMrzdVCR0dHzbbV3d1dk+1UWQGX3sOVAgBJFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkgXxiEWLFpWeGTlyZOmZ9vb20jMRER/72McqzfU2jY2NNdlO1fNE7+BKAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIAyYJ4xAMPPFB65pxzzik909nZWXomIuLwww+vNLez6u7urjRXX1+/nfdk86ruH72DKwUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACQL4hEPPfRQ6ZkNGzaUnunq6io9ExHx6quvVprbWa1Zs6bSXF1d3Xbek82r1cJ77JxcKQCQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIFkQj3juuedKz6xevbr0TGNjY+mZiIj+/fuXnhk+fHjpmf/85z+lZ6ro7OysNNe3b22+XC2It2tzpQBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACSrpFJJlRVPq66+2dDQUHpmZ14ldfny5ZXmDjzwwNIzbW1tpWf69PG94q7M2QcgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQLIgXi9TV1dXeqYoitIzd9xxR+mZs846q/RMRLUF2saPH196ZsGCBaVnqli3bl1NthNR7e/DypUrt/+O8IHhSgGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAMmCeL1MrRbE+8Mf/lB65qtf/WrpmYiIzs7O0jNTpkwpPTNjxozSM1X07Vvty67Keaoys2HDhtIz9B6uFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkCyI18v06VO+8xs3biw9M3/+/NIzb7zxRumZiIjGxsbSM1WeU608+eSTleY++tGPlp558803S8/ss88+pWfoPVwpAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIAySqpvUx3d/eO3oUtev755yvNHXXUUaVnBgwYUHrm6KOPLj3z0EMPlZ6pr68vPRMR0b9//9Iz/fr1Kz0zePDg0jP0Hq4UAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQLIjXyxRFsaN3YYvmzJlTae7pp58uPXPLLbeUnqmyuF0Vc+fOrTTX3NxcembNmjWlZx588MHSM/QerhQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJDqip15BTUAasqVAgBJFABIogBAEgUAkigAkEQBgCQKACRRACCJAgDp/wAfIut//lzmwgAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGbCAYAAAAr/4yjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAFe9JREFUeJzt3XuQlXX9wPHPsuwul2EBcQHvxmoGOGVl2oSIkygqXSY1b6OzqIl5mfKPzGhKZZwyp5ppipGkyUs0TTNKNY5GKjOYM5WFt9BUQgMVBhS5urssyy7P7w/Hz88VUJ5HXJB9vWb8Y8+ez/k+5xzgfZ6zZ7/WFEVRBABERL89fQAA7D1EAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEgT7vxhtvjMMPP3xPH8YumTZt2ofmWPlwEoX3oaamZpf+e/jhh/f0ofYwbdq0XTruadOm7elD3assX768x+NTW1sbhx56aHzlK1+Jp556ak8f3rvynLOr+u/pA/gwmzt3bo+vf/Ob38RDDz203eVjx47tzcN6T5dffnlMnjw5v162bFlcf/31MX369Jg4cWJe3tzcvCcOb693/vnnxxlnnBHd3d3x3HPPxezZs2P+/Pnx6KOPxjHHHLOnD2+HPOfssoLd5qqrrip25SFta2vrhaPZdYsWLSoiorjjjjve9Xqtra29c0C72ebNm4vu7u6dfv+GG24oDjvssPe8nWXLlhURUfz4xz/ucfm9995bREQxffr0nc7urseupaVll471vfT155yd8/bRB+ykk06Ko48+Oh5//PE48cQTY9CgQfHd7343It58++nGG2/cbubwww/f7jR+w4YNcc0118QhhxwSDQ0NccQRR8Qtt9wS27Zt63G9VatWxfPPPx9bt259X8d95513Rk1NTfz1r3+NK6+8MkaOHBkHH3xwfv/WW2+N8ePHR0NDQxx44IFx1VVXxYYNG97zfkS8+ZicdNJJPS77xS9+EePHj49BgwbF8OHD49hjj43f/e53Pa6zcuXKuOSSS2LUqFHR0NAQ48ePj9tvv73HdR5++OGoqamJ3//+9/G9730vDjrooBg0aFBs2rTpfT0e7+bzn/98RLz56jvivR+7+fPnx8SJE2Pw4MExZMiQmDp1avznP//Z7nb/9Kc/xdFHHx0DBgyIo48+Ov74xz/ucH3Pee8/5/sybx/1grVr18bpp58e5513Xlx44YUxatSoUvPt7e0xadKkWLlyZVx++eVx6KGHxt///veYMWNGrFq1Kn72s5/ldWfMmBF33XVXLFu2bLf8QPLKK6+MpqamuP7666OtrS0i3vzB7MyZM2Py5MlxxRVXxJIlS2L27NmxaNGi+Nvf/hZ1dXWl1vjVr34V3/jGN+Lss8+Ob37zm9HR0RGLFy+Of/7zn3HBBRdERMSrr74an/3sZ6OmpiauvvrqaGpqivnz58ell14amzZtimuuuabHbd50001RX18f3/rWt2LLli1RX1//vh+LnXnxxRcjImLEiBE9Lt/RYzd37txoaWmJKVOmxC233BLt7e0xe/bsOOGEE+LJJ5/M5+zBBx+Ms846K8aNGxc333xzrF27Ni6++OIe/0i/xXP+pt58zvdpe/pUZV+yo7ePJk2aVERE8ctf/nK760dEccMNN2x3+WGHHVa0tLTk1zfddFMxePDg4r///W+P633nO98pamtri5dffjkva2lpKSKiWLZs2S4f947eSrjjjjuKiChOOOGEoqurKy9/7bXXivr6+uLUU0/tcXo+a9asIiKK22+/faf34y2TJk0qJk2alF9/+ctfLsaPH/+ux3jppZcWBxxwQPH666/3uPy8884rhg4dWrS3txdFURQLFy4sIqIYM2ZMXvZeyr59NHPmzGLNmjXF6tWri4cffrj45Cc/WUREMW/evKIodv7YvfHGG8WwYcOKyy67rMftrl69uhg6dGiPy4855pjigAMOKDZs2JCXPfjgg0VEbHesnvPyzzk75+2jXtDQ0BAXX3xx5fm77747Jk6cGMOHD4/XX389/5s8eXJ0d3fHI488kte98847oyiK3faxxcsuuyxqa2vz6wULFkRnZ2dcc8010a9fvx7Xa2xsjPvvv7/0GsOGDYsVK1bEokWLdvj9oihi3rx58cUvfjGKoujxGEyZMiU2btwYTzzxRI+ZlpaWGDhwYOlj2RU33HBDNDU1xejRo+Okk06KF198MW655ZY488wze1zvnY/dQw89FBs2bIjzzz+/x32ora2N448/PhYuXBgRb74d9NRTT0VLS0sMHTo050855ZQYN27cdsfjOX/TB/mc9yXePuoFBx100Ps6lV26dGksXrw4mpqadvj91157rfJtv5ePfOQjPb5+6aWXIiLiqKOO6nF5fX19jBkzJr9fxnXXXRcLFiyI4447Lo444og49dRT44ILLogJEyZERMSaNWtiw4YNMWfOnJgzZ84Ob+Odj8E7j3t3mj59enz1q1+Nfv36xbBhw/J99nd65zEsXbo0Iv7/ZxDv1NjYGBH//xgfeeSR213nqKOO2u4fw93Nc963iUIvKPvqpbu7u8fX27Zti1NOOSW+/e1v7/D6H/3oRysf23t5P6+8ampqdnh5d3d3j1eiY8eOjSVLlsR9990Xf/nLX2LevHlx6623xvXXXx8zZ87MH6ZfeOGF0dLSssPb/PjHP77bjvu9HHnkkT0+3rkz7zyGt+7H3LlzY/To0dtdv3//veOvo+e8b9s7/hT2UcOHD9/u0xudnZ2xatWqHpc1NzdHa2vrLv1D9EE77LDDIiJiyZIlMWbMmLy8s7Mzli1b1uMYd3T/It585fn22YiIwYMHx7nnnhvnnntudHZ2xplnnhk/+MEPYsaMGdHU1BRDhgyJ7u7uveIxqOqt3wEYOXLku96Ptx7jt84s3m7JkiUfzMG9C8953+JnCntQc3Nzj58HRETMmTNnuzOFc845J/7xj3/EAw88sN1tbNiwIbq6uvLr3fXxxJ2ZPHly1NfXx89//vMoiiIv//Wvfx0bN26MqVOn5mXNzc3x6KOPRmdnZ1523333xSuvvNLjNteuXdvj6/r6+hg3blwURRFbt26N2traOOuss2LevHnxzDPPbHdMa9as2V137wM1ZcqUaGxsjB/+8Ic7fH7euh8HHHBAHHPMMXHXXXfFxo0b8/sPPfRQPPvss9vNec7ZnZwp7EFf+9rX4utf/3qcddZZccopp8S///3veOCBB2L//ffvcb1rr7027r333vjCF74Q06ZNi09/+tPR1tYWTz/9dNxzzz2xfPnynNndH098p6amppgxY0bMnDkzTjvttPjSl74US5YsiVtvvTU+85nPxIUXXtjj/t1zzz1x2mmnxTnnnBMvvvhi/Pa3v93ut2ZPPfXUGD16dEyYMCFGjRoVzz33XMyaNSumTp0aQ4YMiYiIH/3oR7Fw4cI4/vjj47LLLotx48bFunXr4oknnogFCxbEunXrdvt93d0aGxtj9uzZcdFFF8WnPvWpOO+886KpqSlefvnluP/++2PChAkxa9asiIi4+eabY+rUqXHCCSfEJZdcEuvWrcvP9be2tva4Xc85u9We+tjTvmhnH0nd2Ufvuru7i+uuu67Yf//9i0GDBhVTpkwpXnjhhR1+rO+NN94oZsyYURxxxBFFfX19sf/++xef+9znip/85CdFZ2dnXm93fzxx0aJFO5yZNWtW8bGPfayoq6srRo0aVVxxxRXF+vXrt7veT3/60+Kggw4qGhoaigkTJhSPPfbYdh9PvO2224oTTzyxGDFiRNHQ0FA0NzcX1157bbFx48Yet/Xqq68WV111VXHIIYcUdXV1xejRo4uTTz65mDNnTl7nrY8n3n333bt8/9/vbzS/03s9dgsXLiymTJlSDB06tBgwYEDR3NxcTJs2rXjsscd6XG/evHnF2LFji4aGhmLcuHHFH/7whx3+RrPnvPxzzs7VFMXbzgehD7rxxhvjzjvvjOXLl+/pQ4E9zs8UAEiiAEASBQCSnykAkJwpAJBEAYC0y7+8trM9Tfjw29lGe+9m+vTppWfe/tu5ZWzevLnSXFlVjq/Ku69v3wOojCqbKlbZLLHK/1P87b/BzN5rV/68OlMAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEDa5Q3x2HedffbZpWe+//3vl55Zt25d6ZmIiFWrVpWeGTNmTOmZFStWlJ5ZunRp6ZmxY8eWnomI6OjoKD2zYMGC0jOjRo0qPTN37tzSM+ydnCkAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACDZEI8YOXJk6Znly5eXnunu7i49U1WVTfRqa2tLz4wYMaL0TGNjY+mZiIhNmzaVnjnwwANLzzz//POlZ9h3OFMAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSXVKptNPnmjVrSs+MGTOm9ExExLp160rPDBkypPRMa2tr6Zlhw4aVnqmpqSk9E1HtPm3btq30zNNPP116hn2HMwUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACQb4hEvvfRS6ZlPfOITpWeqbM5Wda69vb30TGdnZ+mZfv3Kv65avXp16ZmIiP3226/0TJXje/7550vPsO9wpgBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgGRDPCptOLd48eLSM21tbaVnIiJqampKzzQ3N5eeGT58eOmZKse2dOnS0jNV/e9//ys909XV9QEcCR8WzhQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBsiEcURVF6ZsWKFaVnnn322dIzVZ199tmlZ0aMGFF6Zvz48aVnHnnkkdIzERGPP/546ZmVK1eWnqmvry89097eXnqGvZMzBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJBviEc8991zpmZNPPrlX1omI2LJlS+mZKpvv/etf/yo9c9ttt5WeeeWVV0rPRFTbhHD9+vWlZzZv3lx6hn2HMwUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACDZJZUYNGhQ6Zm2trbSM6NHjy49E1Ftp88q+vcv/9ehoaGh9Ey/ftVei3V0dJSe6erqKj0zYMCA0jNVdrJl7+RMAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIAyYZ4VNrcrsometu2bSs9ExFx4IEHlp6psrndk08+WXqmKIrSMwMHDiw9ExFRV1dXeqa2trb0zNatW0vPsO9wpgBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgGRDPKK9vb30TJXN7VpbW0vPVFVlraeeemr3H8gOVN0Qr6Ojo/TMli1bSs/YEK9vc6YAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYBkQzwqbW5XZdO0oihKz1Sd663N9zZv3lx6pr6+vtJabW1tpWe6urpKz3R3d5eeYd/hTAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEh2SSVef/310jNVdi7t16/aa5Aqu4p2dHRUWqusKrux1tTUVFqryn1auXJl6Zkqu+ay73CmAEASBQCSKACQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAZEM8YtWqVaVnqmxSV9WgQYNKz9TV1X0AR7K9/v3L/xVqa2urtNamTZtKz9TW1lZai77LmQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIN8Yj29vZemam6EVy/fuVfu+y3336V1iqryn1qaGiotFZHR0fpmbVr11Zai77LmQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIN8Yju7u7SM62traVnqmxsFxHRv3/5P6Zr1qyptFZZS5cuLT0zcODASmvV19eXnhkwYECltei7nCkAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACDZEI9K6urqSs8MHz680lpVNsRbv359pbXKevbZZ0vPHHzwwZXWamxsLD3T3t5eaS36LmcKACRRACCJAgBJFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAsksqlYwYMaL0zNKlSyutdcYZZ5Seue222yqtVdYTTzxReua4446rtNaKFStKz9TW1lZai77LmQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIN8ahk0qRJpWeam5srrXX66aeXnrnooosqrVXWM888U3pmv/32q7TW1VdfXXpm8eLFpWcef/zx0jPsO5wpAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAg2RCPqKmpKT1TW1tbeubII48sPRMR8cILL5Se6ejoqLRWWV1dXaVnhg4dWmmt448/vvRMXV1dpbXou5wpAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAg2RCPKIqi9Ex9fX3pmYEDB5aeiYjYsmVLpbneUGXDuf79q/21q7KRXtW16LucKQCQRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAINkti0o6OztLzzQ2NlZaq62trdJcb+jq6io9093dXWmtKpvvrV69utJa9F3OFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgGSXVCrZvHlz6ZkBAwZUWqujo6PSXG+osltsTU1NpbX69Sv/Gm7r1q2V1qLvcqYAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYBkQzwqGT16dOmZ2traSmtV2Qiut7S2tpae2bZtW6W1qjx+VTYupG/be/+2AdDrRAGAJAoAJFEAIIkCAEkUAEiiAEASBQCSKACQRAGAJAoAJFEAINkQj0peffXV0jMjR46stFZXV1elud6wfv360jPd3d2V1mpoaCg989prr1Vai77LmQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIN8ajkz3/+c+mZY489ttJa27ZtqzTXG954443SM5s2baq01oABA0rPLF++vNJa9F3OFABIogBAEgUAkigAkEQBgCQKACRRACCJAgBJFABIogBAEgUAkigAkEQBgGSXVCrp6OgoPVNll8+IiO7u7kpze6uBAwdWmhs8eHDpmZUrV1Zai77LmQIASRQASKIAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIN8ahk7ty5pWcmTpxYaa358+dXmttb3Xvvvb221tNPP91ra7FvcKYAQBIFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFAJIoAJBEAYBUUxRFsacPAoC9gzMFAJIoAJBEAYAkCgAkUQAgiQIASRQASKIAQBIFANL/AaqYFsPaVVjIAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGbCAYAAAAr/4yjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAHD5JREFUeJzt3XtslvX9xvGrLeXpidIDhQLaciyB4QB1YFTkpDKWhYkMwzxwkOk0DGUTjBodMI2/aVhGjDhlUZyMzYkLG0tgwhTY5kTDsgHKiigFFQrlVKTn0/37Y+ETS1H6+WpLKe9Xwh99el/36bnp1ft52k/joiiKBACApPhzvQMAgLaDUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlLAOTFjxgylpaU1a9m4uDgtXLiwRfZj06ZNiouL0969e1tk/V+lF198sVX29dR2tm7detZlR48erdGjR7fo/qB1UQptTFxcXLP+bdq06Vzv6hmVlZVpwYIFGjx4sFJTU5Wdna2hQ4fq3nvv1YEDB1p8+2vXrm2xAunVq1ej56Br164aOXKkVq9e3SLb+6o1NDTopZde0ogRI5SVlaVOnTqpoKBA06ZN05YtW1p8+zt37tTChQvPiwK+kHU41zuAxlasWNHo45deekkbNmxo8vjAgQNbc7eapba2Vtdcc40KCws1ffp0zZkzR2VlZXrvvff029/+VpMmTVKPHj3c662srFSHDs27VNeuXaulS5e2WDEMHTpU9913nyTpwIEDeu6553TjjTfql7/8pe66664W2eZX5Z577tHSpUv1ne98R7fccos6dOigXbt2ad26derTp4+uuOIK9zrXr1/f7GV37typRYsWafTo0erVq5d7W2gdlEIbc+uttzb6eMuWLdqwYUOTx09XUVGhlJSUlty1s/rjH/+of//731q5cqVuvvnmRp+rqqpSTU1N0HqTkpLOukx5eblSU1OD1u/Rs2fPRs/FtGnT1K9fP/3iF7/43FKoq6tTQ0ODOnbs2OL793kOHTqkZ555RnfccYeWLVvW6HNLlizR4cOHg9bbnGOqqqo6p8cOH14+Og+NHj1agwcP1r/+9S9dc801SklJ0UMPPSTp819/79Wrl2bMmNHosdLSUs2dO1cXX3yxYrGY+vXrpyeeeEINDQ2NlisuLlZhYaFqa2u/cL8+/PBDSdJVV13V5HNJSUlKT09v8vj+/ft1ww03KC0tTTk5OZo3b57q6+sbLXP6MS1cuFBxcXHauXOnbr75ZmVmZurqq6/WjBkztHTpUsuc+teScnNzNXDgQBUVFUmS9u7dq7i4OC1evFhLlixR3759FYvFtHPnTklSYWGhvvvd7yorK0tJSUm6/PLLtWbNmibrfe+99zR27FglJyfroosu0mOPPdbkeZGkEydOqLCwUCdOnPjC/SwqKlIURWd8bk69FHa66upq/fjHP1ZOTo5SU1M1adKkJuVx+nsKp96jefnll/Xwww+rZ8+eSklJ0VNPPaUpU6ZIksaMGdPmXwa9kHGncJ46evSoJkyYoKlTp+rWW29Vt27dXPmKigqNGjVK+/fv1w9+8APl5eXpn//8px588EEVFxdryZIltuyDDz6oX//61yoqKvrC2/78/HxJ/3vJ6+GHHz7rF+T6+nqNHz9eI0aM0OLFi/XXv/5VP//5z9W3b1/dfffdZz2GKVOmqH///nr88ccVRZGGDRumAwcOnPHltpZSW1urjz/+WNnZ2Y0eX758uaqqqnTnnXcqFospKytL7733nq666ir17NlTDzzwgFJTU/XKK6/ohhtu0B/+8AdNmjRJknTw4EGNGTNGdXV1ttyyZcuUnJzcZPurV6/WzJkztXz58ial/1mnnptVq1ZpypQpzbqrnDNnjjIzM7VgwQLt3btXS5Ys0Q9/+EP9/ve/P2v20UcfVceOHTVv3jxVV1fr+uuv1z333KOnnnpKDz30kL382RZfBr3gRWjTZs+eHZ3+NI0aNSqSFD377LNNlpcULViwoMnj+fn50fTp0+3jRx99NEpNTY3ef//9Rss98MADUUJCQvTRRx/ZY9OnT48kRUVFRV+4rxUVFdGAAQMiSVF+fn40Y8aM6Pnnn48OHTrUZNlT6/zpT3/a6PFhw4ZFl1122Rce04IFCyJJ0fe+970m6z3T+foiGzdubNaxRdH/zuH1118fHT58ODp8+HC0bdu2aOrUqZGkaM6cOVEURVFRUVEkKUpPT49KSkoa5ceNGxddcsklUVVVlT3W0NAQXXnllVH//v3tsblz50aSorffftseKykpiTp37txkX5cvXx5JipYvX37W/Z82bVokKcrMzIwmTZoULV68OPrvf//bZLlT67z22mujhoYGe/xHP/pRlJCQEJWWltpjo0aNikaNGmUfnzqfffr0iSoqKhqtd9WqVZGkaOPGjWfdV5w7vHx0norFYpo5c2ZwftWqVRo5cqQyMzN15MgR+3fttdeqvr5ef/vb32zZF198UVEUnfXNweTkZL399tuaP3++5WbNmqXu3btrzpw5qq6ubpI5/XX4kSNHas+ePc06hnPxxu769euVk5OjnJwcDRkyRKtWrdJtt92mJ554otFykydPVk5Ojn187NgxvfHGG7rpppt08uRJO99Hjx7V+PHjtXv3bu3fv1/S/94sv+KKKzR8+HDL5+Tk6JZbbmmyPzNmzFAURV94l3DK8uXL9fTTT6t3795avXq15s2bp4EDB2rcuHG27c+68847G93tjRw5UvX19dq3b99ZtzV9+vQz3tmg7ePlo/NUz549v9Sbd7t379b27dsbfeH6rJKSkqD1du7cWU8++aSefPJJ7du3T6+//roWL16sp59+Wp07d9Zjjz1myyYlJTXZfmZmpo4fP96sbfXu3TtoH7+MESNG6LHHHlNcXJxSUlI0cOBAZWRknHXfPvjgA0VRpEceeUSPPPLIGdddUlKinj17at++fRoxYkSTzw8YMOBL7Xt8fLxmz56t2bNn6+jRo3rzzTf17LPPat26dZo6dar+/ve/N1o+Ly+v0ceZmZmS1Kzn51w8N/hqUArnKe93Yae/edvQ0KDrrrtO999//xmXLygoCN63U/Lz83X77bdr0qRJ6tOnj1auXNmoFBISEr7U+s/Fd6JdunTRtddee9blTt+3U28Sz5s3T+PHjz9jpl+/fl9+B5spOztbEydO1MSJEzV69Ght3rxZ+/bts/cepM9/fqJm/AVf7hLOX5RCO5OZmanS0tJGj9XU1Ki4uLjRY3379lVZWVmzvsB9FfvUt29fvfvuuy2+rZb+aaNQffr0kSQlJiae9Zzn5+dr9+7dTR7ftWtXi+zb5Zdfrs2bN6u4uLhRKXzV2upzg8Z4T6Gd6du3b6P3AyRp2bJlTe4UbrrpJr311lt67bXXmqyjtLRUdXV19nFzfyR127ZtOnLkSJPH9+3bp507d37plz+a49TvKpxejOda165dNXr0aD333HNNClpSox/1/Na3vqUtW7bonXfeafT5lStXNsk190dSDx48aD8W+1k1NTV6/fXXFR8f3+J3Km31uUFj3Cm0M9///vd11113afLkybruuuu0bds2vfbaa+rSpUuj5ebPn681a9bo29/+tmbMmKHLLrtM5eXl2rFjh1599VXt3bvXMs39kdQNGzZowYIFmjhxoq644gqlpaVpz549euGFF1RdXd1iv2X8WZdddpmk//327vjx45WQkKCpU6e2+HabY+nSpbr66qt1ySWX6I477lCfPn106NAhvfXWW/rkk0+0bds2SdL999+vFStW6Jvf/Kbuvfde+5HU/Px8bd++vdE6m/sjqZ988omGDx+usWPHaty4ccrNzVVJSYl+97vfadu2bZo7d26Ta+SrNnToUCUkJOiJJ57QiRMnFIvFNHbs2DP+jgTOHUqhnbnjjjtUVFSk559/Xn/5y180cuRIbdiwQePGjWu0XEpKijZv3qzHH39cq1at0ksvvaT09HQVFBRo0aJF6ty5s3vbkydP1smTJ7V+/Xq98cYbOnbsmDIzMzV8+HDdd999GjNmzFd1mJ/rxhtv1Jw5c/Tyyy/rN7/5jaIoajOlMGjQIG3dulWLFi3Siy++qKNHj6pr164aNmyYfvKTn9hy3bt318aNGzVnzhz97Gc/U3Z2tu666y716NFDs2bNCtr2gAEDtGTJEq1du1bPPPOMDh06pKSkJA0ePFi/+tWvgtfrkZubq2effVb/93//p1mzZqm+vl4bN26kFNqYuKg57xoB7dSmTZs0ZsyYs94FARcK3lMAABhKAQBgKAUAgOE9BQCA4U4BAGAoBQCAafbvKbT1X1GPj/f325n+aMnZtNZ5aI+v6oX8uUdJQX9RLWRY4JedxdRcsVgsKBfy19FO/+12XNia83WFOwUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgmv33FNr6QLy2vH+tOdyuU6dO7szYsWPdmUsvvdSdmTBhgjsjSbt27XJnQs55WlqaO5Odne3OHDlyxJ2RpOTkZHcmZMjfn//8Z3dmzZo17sxHH33kzuDLYSAeAMCFUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgGk3A/FChBxTaw23u/POO4NyBQUF7kzI0LTCwkJ3JmTgnCQNHTrUnamqqnJnUlNT3ZmysjJ35tNPP3VnJKmiosKdycnJcWdCjql3797uTMjxSNIDDzzgzhw4cCBoW+0NA/EAAC6UAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADDtZkpqW554evfdd7sz2dnZQdsqLS11Z2pra92Z+Hj/9xMh0zclKRaLuTOTJk1yZw4ePOjOhEz6DJngKknvvPOOOzNhwgR3ZseOHe5MyITZ/Px8d0YKm+p7++23B22rvWFKKgDAhVIAABhKAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIDpcK534KvSWgPxLr74YncmLy/PndmzZ487I0lpaWlBOa/y8nJ3plu3bkHb+vDDD92ZkPPXv39/d+bo0aPuTMhgO0m65ppr3Jn9+/e7M0lJSe5McnKyO1NZWenOSFJubq47c9ttt7kzK1ascGdCB4e21nDO5uBOAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAAJh2MxCvoaGhVbbTr18/d6aurs6d6dAh7KkpKytzZ2KxmDuTkJDgzoTsmyRlZGS4M2vXrnVnHn/8cXcmZKhb6HMbkjt06JA7k5qa6s6kp6e7Mx07dnRnJKm6utqdGTZsmDsTMhCvLQ22C8WdAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADDtZiBea/na177mzlRVVbkzIUPqQpWXl7szIQPx6uvr3RkpbNhacXGxO7N+/Xp3JmTYYeh5+OCDD9yZuLg4dyY3N9edCRnWl5SU5M6E+sY3vtFq2zrfcacAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADAPxnC666CJ35sSJE+5Maw7EKykpcWdSUlLcmZChaZJUU1PjzoQMLty+fbs7k5WV5c4cOHDAnZGkHj16uDMZGRnuTLdu3dyZkAGEIc+RJBUVFbkzx44dc2c6duzozoRcq20NdwoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAHNBT0kNmQYZIi0tzZ3JzMwM2lbIpM/a2lp3JiEhwZ0J1dDQ4M5UV1e7MyHnPGSSZlxcnDsjhU2Z7d69uzsTcu5CzkPIBNdQ8fH+73+//vWvuzNbt251Z9oa7hQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAuaAH4vXu3dudKSsrc2disZg7k5qa6s5IUhRF7kxWVpY7k5iY6M4kJSW5M6FCBqDV19e7MyHD+nJyctyZUCHXXsjgvZSUFHfm5MmT7owUdkx1dXXuTMjXBwbiAQDaFUoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAADmgh6Il5eX585UVVW5MyHD2UKFHNO+ffvcmZqaGncmISHBnQnNhQwuDBmaFnK+Q89DyP5VV1e7MyED8bp37+7OVFRUuDOSVFtb2yqZgoICd6Y94E4BAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAmAt6IF6PHj3cmfr6enfm008/dWdisZg7I0np6enuTENDgzsTMjQt5NxJYQPkoihyZ0LOeci+nTx50p2RpMzMTHcmZIBjcnKyOxNyjXfp0sWdkaTS0lJ3JmQo5dChQ92Z9oA7BQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAuaCnpKalpbkzNTU17szx48fdmby8PHdGkv70pz+5MyHnIWQKaW1trTsjhU0vDckkJia6MyHHFDJhVpKSkpLcmZAJuCGTVQsLC92ZiRMnujNS2LUX8v825Hy3B9wpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAHNBD8QLGZpWWVnpztTV1bkzcXFx7owk7dy5050ZOXKkO1NWVubOhKqvr3dnMjIy3JmQwYUhw9lCrgcpbPhe6HXk9f7777szKSkpQdsKOabq6mp3JuQaag+4UwAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACm3QzE69DBfygdO3Z0ZxISEtyZECHDzyTpwIED7kxrDU1LTk4OyoUMxEtNTXVnjh496s6EDMQLyUitNxAv5BrfvXu3OxM6EC8+3v+9bMjXh5BrKC0tzZ2RWnfA5NlwpwAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAABMuxmI16VLF3cmZFhYyDCzkGFcNTU17kzotkIydXV17kwsFnNnJOnYsWPuTEVFhTuTmJjozoQM+SspKXFnpLDBgCHXeMh2iouLW2U7oSorK92ZkP/rubm57owkffDBB0G5lsCdAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADDtZiBeRkaGOxMyCK6qqsqdCdm3jz/+2J2RpJMnT7ozqamp7szBgwfdmZDzLUnx8f7vXUKGrSUlJbkzIQPxQgfBhQwhDDnnaWlprZIJHQzY0NDgzoSch5DrrmvXru6MxEA8AEAbRSkAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAA026mpEZR5M6UlZW5M9XV1e5MQUGBO1NYWOjOSGHHFDJ9M0RCQkJQLjEx0Z0JuR5CJuBWVla6MyHTWKWwqZ0hsrKy3Jny8nJ3ZseOHe6MJHXq1MmdOX78uDsTMo01ZFpsW8OdAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADDtZiBedna2OxMyCC45OdmdycjIcGe2b9/uzkhSTk6OOxMyYCxEhw5hl1ssFnNnQga01dfXuzMhQ9NCriEpbKBgbW2tOxNyTHl5ee7Mhx9+6M5I0pVXXunOhJzzkKGU6enp7kxbw50CAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMO1mIN6ll17qzoQMyQrJdOvWzZ05fvy4OyNJl19+uTtTUVHhzoQMTQvJSGGD4GpqalplOyGZ+Piw78Wqq6tbJRMyKHLIkCHuzIkTJ9wZSaqsrHRnkpKS3JnU1FR3JuT/nyS9+uqrQbmWwJ0CAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMO1mIF55ebk7EzIkq2fPnu5Mp06d3Jn//Oc/7owkDR061J0pLS11Z1JSUtyZUHFxce5MLBZzZ0KG29XX17szIdeqFDbkL2S4Xcjgwl69erkza9ascWck6YUXXnBnXnnlFXcm5HkqLi52Z9oa7hQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAGEoBAGAoBQCAiYuiKGrWggFDydqjtLQ0d6ZPnz7uzLvvvuvOSNL8+fPdmePHj7szIQPn0tPT3RlJ2r9/vzvTpUsXdyYxMdGdCbkePvnkE3cmVPfu3d2Zrl27ujO9e/d2Z2bOnOnOSGGDAcvKytyZqqoqd6ata86Xe+4UAACGUgAAGEoBAGAoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACmw7negfNNyLTF7du3uzOdOnVyZyQpOzvbnTl27Jg706GD/9I5dOiQOyNJycnJ7kzIeQiZBBwysbOZg4mbCJlMW11dHbQtr5SUFHdmyJAhQdtat25dUA7Nw50CAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMBf0QLyQAWjx8f4era+vd2euvvpqd0aSamtrg3JelZWV7kzIuZOkfv36uTNFRUVB2/Lq1q2bOxNy3UlSUlKSO1NRUeHOhDy3+/fvd2dGjRrlzkhhA/FCznno4MLzHXcKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFzQA/FCBl6FDLcLMWDAgKDciRMn3JmOHTu6MyHnoaCgwJ2RpL1797oz5eXl7kyPHj3cmZAhdaGDAZOTk92ZkEFwNTU1rZLJzc11Z0KF/F+/UIfocacAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwlAIAwFAKAABDKQAAzAU9EC9EQkKCOxMyPC4/P9+dkcKG2+3evdudaWhocGd27drlzkjSsWPH3JlBgwa5MyHHlJiY6M6EDlU8efKkO9NaAxJjsZg7k5KS4s6Ebqu6utqdYSAeAOCCRykAAAylAAAwlAIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAExc1c6xfyMTA9ig+3t+jIdM3k5OT3RlJmj9/vjtz1VVXuTMZGRnuTFFRkTsjSbW1te5MyPk7fPiwO5OZmenOlJeXuzOSlJWV5c5069bNnQmZrHrkyBF35rnnnnNnJOkf//hHUA7Nm+LKnQIAwFAKAABDKQAADKUAADCUAgDAUAoAAEMpAAAMpQAAMJQCAMBQCgAAQykAAAylAAAwDMRDkLy8PHdm0KBBQdsKGeqWnp7uzoQMOwxRU1MTlKurq3NnPvroI3fmzTffdGfKysrcGbQ+BuIBAFwoBQCAoRQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAACGUgAAmA7NXbCZc/MAAOcx7hQAAIZSAAAYSgEAYCgFAIChFAAAhlIAABhKAQBgKAUAgKEUAADm/wH8rEgKuOHuEQAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import requests\n",
+        "from pathlib import Path\n",
+        "\n",
+        "# Download helper functions from Learn PyTorch repo (if not already downloaded)\n",
+        "if Path(\"helper_functions.py\").is_file():\n",
+        "  print(\"helper_functions.py already exists, skipping download\")\n",
+        "else:\n",
+        "  print(\"Downloading helper_functions.py\")\n",
+        "  # Note: you need the \"raw\" GitHub URL for this to work\n",
+        "  request = requests.get(\"https://raw.githubusercontent.com/mrdbourke/pytorch-deep-learning/main/helper_functions.py\")\n",
+        "  with open(\"helper_functions.py\", \"wb\") as f:\n",
+        "    f.write(request.content)\n",
+        "# Import accuracy metric\n",
+        "from helper_functions import accuracy_fn # Note: could also use torchmetrics.Accuracy(task = 'multiclass', num_classes=len(class_names)).to(device)\n",
+        "\n",
+        "# Setup loss function and optimizer\n",
+        "loss_fn = nn.CrossEntropyLoss() # this is also called \"criterion\"/\"cost function\" in some places\n",
+        "optimizer = torch.optim.SGD(params=model_0.parameters(), lr=0.1)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "hv8z-jYEmBUs",
+        "outputId": "21f67e5f-762f-488b-f93c-b5c2e0918617"
+      },
+      "execution_count": 41,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "helper_functions.py already exists, skipping download\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Getting the result of model 0"
+      ],
+      "metadata": {
+        "id": "Sf61r-v-lu4W"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "torch.manual_seed(42)\n",
+        "def eval_model(model: torch.nn.Module,\n",
+        "               data_loader: torch.utils.data.DataLoader,\n",
+        "               loss_fn: torch.nn.Module,\n",
+        "               accuracy_fn):\n",
+        "    \"\"\"Returns a dictionary containing the results of model predicting on data_loader.\n",
+        "\n",
+        "    Args:\n",
+        "        model (torch.nn.Module): A PyTorch model capable of making predictions on data_loader.\n",
+        "        data_loader (torch.utils.data.DataLoader): The target dataset to predict on.\n",
+        "        loss_fn (torch.nn.Module): The loss function of model.\n",
+        "        accuracy_fn: An accuracy function to compare the models predictions to the truth labels.\n",
+        "\n",
+        "    Returns:\n",
+        "        (dict): Results of model making predictions on data_loader.\n",
+        "    \"\"\"\n",
+        "    loss, acc = 0, 0\n",
+        "    model.eval()\n",
+        "    with torch.inference_mode():\n",
+        "        for X, y in data_loader:\n",
+        "            # Make predictions with the model\n",
+        "            y_pred = model(X)\n",
+        "\n",
+        "            # Accumulate the loss and accuracy values per batch\n",
+        "            loss += loss_fn(y_pred, y)\n",
+        "            acc += accuracy_fn(y_true=y,\n",
+        "                                y_pred=y_pred.argmax(dim=1)) # For accuracy, need the prediction labels (logits -> pred_prob -> pred_labels)\n",
+        "\n",
+        "        # Scale loss and acc to find the average loss/acc per batch\n",
+        "        loss /= len(data_loader)\n",
+        "        acc /= len(data_loader)\n",
+        "\n",
+        "    return {\"model_name\": model.__class__.__name__, # only works when model was created with a class\n",
+        "            \"model_loss\": loss.item(),\n",
+        "            \"model_acc\": acc}\n",
+        "\n",
+        "# Calculate model 0 results on test dataset\n",
+        "model_0_results = eval_model(model=model_0, data_loader=test_dataloader,\n",
+        "    loss_fn=loss_fn, accuracy_fn=accuracy_fn\n",
+        ")\n",
+        "model_0_results"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4tqUdcmLlxbp",
+        "outputId": "07528999-9895-42c9-edbc-ffff49e81a25"
+      },
+      "execution_count": 42,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'model_name': 'FashionMNISTModelV0',\n",
+              " 'model_loss': 0.4999507963657379,\n",
+              " 'model_acc': 82.26837060702876}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 42
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "we have this now : {'model_name': 'FashionMNISTModelV0',\n",
+        " 'model_loss': 0.4999507963657379,\n",
+        " 'model_acc': 82.26837060702876}"
+      ],
+      "metadata": {
+        "id": "HFk51CaFmVP8"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "lets do all the tasks in a single devices :"
+      ],
+      "metadata": {
+        "id": "04KTrUyamXiT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Setup device agnostic code\n",
+        "import torch\n",
+        "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+        "device"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "id": "9Cg86b0QmyPz",
+        "outputId": "640088f6-a085-4c88-a414-84e94662bbea"
+      },
+      "execution_count": 43,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'cpu'"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 43
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Lets build better model with non-linearuty in the hope that we do better than the very simple baseline by letting the network learn curved/complex patterns instead of only straight‑line patterns."
+      ],
+      "metadata": {
+        "id": "9EeXVzyxm2ux"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class FashionMNISTModelV1(nn.Module):\n",
+        "    \"\"\"\n",
+        "    A better model than baseline:\n",
+        "    - Flattens image [1, 28, 28] -> [784]\n",
+        "    - Two hidden layers with ReLU (non-linearity)\n",
+        "    - Output layer with 10 units (one per class)\n",
+        "    \"\"\"\n",
+        "    def __init__(self, input_shape: int, hidden_units: int, output_shape: int):\n",
+        "        super().__init__()\n",
+        "        self.layers = nn.Sequential(\n",
+        "            nn.Flatten(),                               # [N, 1, 28, 28] -> [N, 784]\n",
+        "            nn.Linear(input_shape, hidden_units),       # [N, 784] -> [N, hidden_units]\n",
+        "            nn.ReLU(),                                  # non-linear activation\n",
+        "            nn.Linear(hidden_units, hidden_units),      # [N, hidden_units] -> [N, hidden_units]\n",
+        "            nn.ReLU(),                                  # another non-linearity\n",
+        "            nn.Linear(hidden_units, output_shape)       # [N, hidden_units] -> [N, 10]\n",
+        "        )\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        return self.layers(x)\n"
+      ],
+      "metadata": {
+        "id": "5Z3QW3OWnNPd"
+      },
+      "execution_count": 44,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "lets move tha to the device and also device loss function and optimizer"
+      ],
+      "metadata": {
+        "id": "eKQAKbO9nmw6"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "input_shape  = 28 * 28          # 784 pixels per image\n",
+        "hidden_units = 64               # you can change this (e.g. 64, 128)\n",
+        "output_shape = len(class_names) # 10 classes\n",
+        "\n",
+        "torch.manual_seed(42)\n",
+        "model_1 = FashionMNISTModelV1(input_shape, hidden_units, output_shape).to(device)\n",
+        "print(model_1)\n",
+        "loss_fn   = nn.CrossEntropyLoss()             # good for multi-class classification\n",
+        "optimizer = torch.optim.SGD(model_1.parameters(), lr=0.1)\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "5il_kIysnxOP",
+        "outputId": "01e8745a-df2c-4daa-95b6-957a2c8186e6"
+      },
+      "execution_count": 45,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "FashionMNISTModelV1(\n",
+            "  (layers): Sequential(\n",
+            "    (0): Flatten(start_dim=1, end_dim=-1)\n",
+            "    (1): Linear(in_features=784, out_features=64, bias=True)\n",
+            "    (2): ReLU()\n",
+            "    (3): Linear(in_features=64, out_features=64, bias=True)\n",
+            "    (4): ReLU()\n",
+            "    (5): Linear(in_features=64, out_features=10, bias=True)\n",
+            "  )\n",
+            ")\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "lets train"
+      ],
+      "metadata": {
+        "id": "Pz_Df206n1sJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def train_step(model: torch.nn.Module,\n",
+        "               data_loader: torch.utils.data.DataLoader,\n",
+        "               loss_fn: torch.nn.Module,\n",
+        "               optimizer: torch.optim.Optimizer,\n",
+        "               accuracy_fn,\n",
+        "               device: torch.device = device):\n",
+        "    train_loss, train_acc = 0, 0\n",
+        "    model.to(device)\n",
+        "    for batch, (X, y) in enumerate(data_loader):\n",
+        "        # Send data to GPU\n",
+        "        X, y = X.to(device), y.to(device)\n",
+        "\n",
+        "        # 1. Forward pass\n",
+        "        y_pred = model(X)\n",
+        "\n",
+        "        # 2. Calculate loss\n",
+        "        loss = loss_fn(y_pred, y)\n",
+        "        train_loss += loss\n",
+        "        train_acc += accuracy_fn(y_true=y,\n",
+        "                                 y_pred=y_pred.argmax(dim=1)) # Go from logits -> pred labels\n",
+        "\n",
+        "        # 3. Optimizer zero grad\n",
+        "        optimizer.zero_grad()\n",
+        "\n",
+        "        # 4. Loss backward\n",
+        "        loss.backward()\n",
+        "\n",
+        "        # 5. Optimizer step\n",
+        "        optimizer.step()\n",
+        "\n",
+        "    # Calculate loss and accuracy per epoch and print out what's happening\n",
+        "    train_loss /= len(data_loader)\n",
+        "    train_acc /= len(data_loader)\n",
+        "    print(f\"Train loss: {train_loss:.5f} | Train accuracy: {train_acc:.2f}%\")\n",
+        "\n",
+        "def test_step(data_loader: torch.utils.data.DataLoader,\n",
+        "              model: torch.nn.Module,\n",
+        "              loss_fn: torch.nn.Module,\n",
+        "              accuracy_fn,\n",
+        "              device: torch.device = device):\n",
+        "    test_loss, test_acc = 0, 0\n",
+        "    model.to(device)\n",
+        "    model.eval() # put model in eval mode\n",
+        "    # Turn on inference context manager\n",
+        "    with torch.inference_mode():\n",
+        "        for X, y in data_loader:\n",
+        "            # Send data to GPU\n",
+        "            X, y = X.to(device), y.to(device)\n",
+        "\n",
+        "            # 1. Forward pass\n",
+        "            test_pred = model(X)\n",
+        "\n",
+        "            # 2. Calculate loss and accuracy\n",
+        "            test_loss += loss_fn(test_pred, y)\n",
+        "            test_acc += accuracy_fn(y_true=y,\n",
+        "                y_pred=test_pred.argmax(dim=1) # Go from logits -> pred labels\n",
+        "            )\n",
+        "\n",
+        "        # Adjust metrics and print out\n",
+        "        test_loss /= len(data_loader)\n",
+        "        test_acc /= len(data_loader)\n",
+        "        print(f\"Test loss: {test_loss:.5f} | Test accuracy: {test_acc:.2f}%\\n\")\n"
+      ],
+      "metadata": {
+        "id": "RnXrrZyGn9hS"
+      },
+      "execution_count": 46,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "train_step(model=model_1, data_loader=train_dataloader, loss_fn=loss_fn, optimizer=optimizer, accuracy_fn=accuracy_fn)\n",
+        "test_step(data_loader=test_dataloader, model=model_1, loss_fn=loss_fn, accuracy_fn=accuracy_fn)\n",
+        "\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WMLuyzTOo3h6",
+        "outputId": "19459c6e-1510-4611-ddac-11101500cb88"
+      },
+      "execution_count": 47,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Train loss: 0.61462 | Train accuracy: 77.64%\n",
+            "Test loss: 0.44774 | Test accuracy: 83.91%\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Evaluating this model"
+      ],
+      "metadata": {
+        "id": "prbRp5Sbn_X-"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Move values to device\n",
+        "torch.manual_seed(42)\n",
+        "def eval_model(model: torch.nn.Module,\n",
+        "               data_loader: torch.utils.data.DataLoader,\n",
+        "               loss_fn: torch.nn.Module,\n",
+        "               accuracy_fn,\n",
+        "               device: torch.device = device):\n",
+        "    \"\"\"Evaluates a given model on a given dataset.\n",
+        "\n",
+        "    Args:\n",
+        "        model (torch.nn.Module): A PyTorch model capable of making predictions on data_loader.\n",
+        "        data_loader (torch.utils.data.DataLoader): The target dataset to predict on.\n",
+        "        loss_fn (torch.nn.Module): The loss function of model.\n",
+        "        accuracy_fn: An accuracy function to compare the models predictions to the truth labels.\n",
+        "        device (str, optional): Target device to compute on. Defaults to device.\n",
+        "\n",
+        "    Returns:\n",
+        "        (dict): Results of model making predictions on data_loader.\n",
+        "    \"\"\"\n",
+        "    loss, acc = 0, 0\n",
+        "    model.eval()\n",
+        "    with torch.inference_mode():\n",
+        "        for X, y in data_loader:\n",
+        "            # Send data to the target device\n",
+        "            X, y = X.to(device), y.to(device)\n",
+        "            y_pred = model(X)\n",
+        "            loss += loss_fn(y_pred, y)\n",
+        "            acc += accuracy_fn(y_true=y, y_pred=y_pred.argmax(dim=1))\n",
+        "\n",
+        "        # Scale loss and acc\n",
+        "        loss /= len(data_loader)\n",
+        "        acc /= len(data_loader)\n",
+        "    return {\"model_name\": model.__class__.__name__, # only works when model was created with a class\n",
+        "            \"model_loss\": loss.item(),\n",
+        "            \"model_acc\": acc}\n",
+        "\n",
+        "# Calculate model 1 results with device-agnostic code\n",
+        "model_1_results = eval_model(model=model_1, data_loader=test_dataloader,\n",
+        "    loss_fn=loss_fn, accuracy_fn=accuracy_fn,\n",
+        "    device=device\n",
+        ")\n",
+        "model_1_results"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "BOlwSrLLoWmB",
+        "outputId": "a76ae320-9dfe-4c80-9bb6-f8cf615228bf"
+      },
+      "execution_count": 48,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'model_name': 'FashionMNISTModelV1',\n",
+              " 'model_loss': 0.44774019718170166,\n",
+              " 'model_acc': 83.90575079872204}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 48
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "What the hell , {'model_name': 'FashionMNISTModelV1',\n",
+        " 'model_loss': 0.5445905923843384,\n",
+        " 'model_acc': 79.49281150159744} clearluy shows that the accuracy has decreased . so , this may not be the right kind."
+      ],
+      "metadata": {
+        "id": "QTWdsJc-pKli"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Can you try with the next architecture of CNN then ?? it is best for this type of ision data"
+      ],
+      "metadata": {
+        "id": "WIZogLAIpYZK"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Create a convolutional neural network\n",
+        "class FashionMNISTModelV2(nn.Module):\n",
+        "    \"\"\"\n",
+        "    Model architecture copying TinyVGG from:\n",
+        "    https://poloclub.github.io/cnn-explainer/\n",
+        "    \"\"\"\n",
+        "    def __init__(self, input_shape: int, hidden_units: int, output_shape: int):\n",
+        "        super().__init__()\n",
+        "        self.block_1 = nn.Sequential(\n",
+        "            nn.Conv2d(in_channels=input_shape,\n",
+        "                      out_channels=hidden_units,\n",
+        "                      kernel_size=3, # how big is the square that's going over the image?\n",
+        "                      stride=1, # default\n",
+        "                      padding=1),# options = \"valid\" (no padding) or \"same\" (output has same shape as input) or int for specific number\n",
+        "            nn.ReLU(),\n",
+        "            nn.Conv2d(in_channels=hidden_units,\n",
+        "                      out_channels=hidden_units,\n",
+        "                      kernel_size=3,\n",
+        "                      stride=1,\n",
+        "                      padding=1),\n",
+        "            nn.ReLU(),\n",
+        "            nn.MaxPool2d(kernel_size=2,\n",
+        "                         stride=2) # default stride value is same as kernel_size\n",
+        "        )\n",
+        "        self.block_2 = nn.Sequential(\n",
+        "            nn.Conv2d(hidden_units, hidden_units, 3, padding=1),\n",
+        "            nn.ReLU(),\n",
+        "            nn.Conv2d(hidden_units, hidden_units, 3, padding=1),\n",
+        "            nn.ReLU(),\n",
+        "            nn.MaxPool2d(2)\n",
+        "        )\n",
+        "        self.classifier = nn.Sequential(\n",
+        "            nn.Flatten(),\n",
+        "            # Where did this in_features shape come from?\n",
+        "            # It's because each layer of our network compresses and changes the shape of our input data.\n",
+        "            nn.Linear(in_features=hidden_units*7*7,\n",
+        "                      out_features=output_shape)\n",
+        "        )\n",
+        "\n",
+        "    def forward(self, x: torch.Tensor):\n",
+        "        x = self.block_1(x)\n",
+        "        # print(x.shape)\n",
+        "        x = self.block_2(x)\n",
+        "        # print(x.shape)\n",
+        "        x = self.classifier(x)\n",
+        "        # print(x.shape)\n",
+        "        return x\n",
+        "\n",
+        "torch.manual_seed(42)\n",
+        "model_2 = FashionMNISTModelV2(input_shape=1,\n",
+        "    hidden_units=10,\n",
+        "    output_shape=len(class_names)).to(device)\n",
+        "model_2"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "wVP6LeqpqL9p",
+        "outputId": "f836743f-d930-48c9-bf8c-477a7b0b3eb1"
+      },
+      "execution_count": 49,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "FashionMNISTModelV2(\n",
+              "  (block_1): Sequential(\n",
+              "    (0): Conv2d(1, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+              "    (1): ReLU()\n",
+              "    (2): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+              "    (3): ReLU()\n",
+              "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+              "  )\n",
+              "  (block_2): Sequential(\n",
+              "    (0): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+              "    (1): ReLU()\n",
+              "    (2): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+              "    (3): ReLU()\n",
+              "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+              "  )\n",
+              "  (classifier): Sequential(\n",
+              "    (0): Flatten(start_dim=1, end_dim=-1)\n",
+              "    (1): Linear(in_features=490, out_features=10, bias=True)\n",
+              "  )\n",
+              ")"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 49
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Moving to devices and losss and optimixer"
+      ],
+      "metadata": {
+        "id": "jEvcZLenqSPx"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "input_channels = 1               # grayscale\n",
+        "hidden_units   = 32              # number of filters\n",
+        "output_shape   = len(class_names)\n",
+        "\n",
+        "torch.manual_seed(42)\n",
+        "model_2 = FashionMNISTModelV2(input_channels, hidden_units, output_shape).to(device)\n",
+        "print(model_2)\n",
+        "loss_fn   = nn.CrossEntropyLoss()\n",
+        "optimizer = torch.optim.SGD(model_2.parameters(), lr=0.1)\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "e_wGHRg-qaXC",
+        "outputId": "2580242a-b98c-432e-d2ff-d1cdf539168a"
+      },
+      "execution_count": 50,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "FashionMNISTModelV2(\n",
+            "  (block_1): Sequential(\n",
+            "    (0): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+            "    (1): ReLU()\n",
+            "    (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+            "    (3): ReLU()\n",
+            "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+            "  )\n",
+            "  (block_2): Sequential(\n",
+            "    (0): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+            "    (1): ReLU()\n",
+            "    (2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+            "    (3): ReLU()\n",
+            "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+            "  )\n",
+            "  (classifier): Sequential(\n",
+            "    (0): Flatten(start_dim=1, end_dim=-1)\n",
+            "    (1): Linear(in_features=1568, out_features=10, bias=True)\n",
+            "  )\n",
+            ")\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Lets make the training and evaluation loop"
+      ],
+      "metadata": {
+        "id": "YRubHOJeqfCg"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def train_one_epoch(model, dataloader, loss_fn, optimizer, device):\n",
+        "    model.train()\n",
+        "    epoch_loss = 0\n",
+        "    for X, y in dataloader:\n",
+        "        X, y = X.to(device), y.to(device)\n",
+        "\n",
+        "        y_pred = model(X)\n",
+        "        loss   = loss_fn(y_pred, y)\n",
+        "\n",
+        "        optimizer.zero_grad()\n",
+        "        loss.backward()\n",
+        "        optimizer.step()\n",
+        "\n",
+        "        epoch_loss += loss.item()\n",
+        "\n",
+        "    return epoch_loss / len(dataloader)\n",
+        "\n",
+        "def eval_one_epoch(model, dataloader, loss_fn, device):\n",
+        "    model.eval()\n",
+        "    epoch_loss = 0\n",
+        "    correct    = 0\n",
+        "    total      = 0\n",
+        "\n",
+        "    with torch.inference_mode():\n",
+        "        for X, y in dataloader:\n",
+        "            X, y = X.to(device), y.to(device)\n",
+        "\n",
+        "            logits = model(X)\n",
+        "            loss   = loss_fn(logits, y)\n",
+        "            epoch_loss += loss.item()\n",
+        "\n",
+        "            preds = logits.argmax(dim=1)\n",
+        "            correct += (preds == y).sum().item()\n",
+        "            total   += y.size(0)\n",
+        "\n",
+        "    accuracy = correct / total\n",
+        "    return epoch_loss / len(dataloader), accuracy\n"
+      ],
+      "metadata": {
+        "id": "l8823BwOqiji"
+      },
+      "execution_count": 51,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "lets train and evaluate then"
+      ],
+      "metadata": {
+        "id": "ZN3GXQO1qmMF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# create a dict to store Model 2 results\n",
+        "model2_results = {\n",
+        "    \"model_name\": \"Model_2_CNN\",\n",
+        "    \"train_loss\": [],\n",
+        "    \"test_loss\": [],\n",
+        "    \"test_acc\": []\n",
+        "}\n",
+        "\n",
+        "EPOCHS = 1\n",
+        "\n",
+        "for epoch in range(EPOCHS):\n",
+        "    train_loss = train_one_epoch(model_2, train_dataloader, loss_fn, optimizer, device)\n",
+        "    test_loss, test_acc = eval_one_epoch(model_2, test_dataloader, loss_fn, device)\n",
+        "\n",
+        "    # save results for this epoch\n",
+        "    model2_results[\"train_loss\"].append(train_loss)\n",
+        "    model2_results[\"test_loss\"].append(test_loss)\n",
+        "    model2_results[\"test_acc\"].append(test_acc)\n",
+        "\n",
+        "    print(f\"Epoch {epoch+1}: \"\n",
+        "          f\"Train loss = {train_loss:.4f}, \"\n",
+        "          f\"Test loss = {test_loss:.4f}, \"\n",
+        "          f\"Test acc = {test_acc:.4f}\")\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "115c52eOqsCE",
+        "outputId": "0f64d1b9-2c97-4c17-f14e-27518ecf13e8"
+      },
+      "execution_count": 56,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1: Train loss = 0.2954, Test loss = 0.2969, Test acc = 0.8949\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "this seems to be best model till now . so comparing the resuls"
+      ],
+      "metadata": {
+        "id": "9prJCKu5rGG7"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "compare_results = pd.DataFrame([model_0_results, model_1_results,model2_results])\n",
+        "compare_results"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 143
+        },
+        "id": "nl38z_yjrV4E",
+        "outputId": "df8e37b3-c972-42e1-9064-ae7d164ac291"
+      },
+      "execution_count": 60,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "            model_name  model_loss  model_acc            train_loss  \\\n",
+              "0  FashionMNISTModelV0    0.499951  82.268371                   NaN   \n",
+              "1  FashionMNISTModelV1    0.447740  83.905751                   NaN   \n",
+              "2          Model_2_CNN         NaN        NaN  [0.2954221625546614]   \n",
+              "\n",
+              "              test_loss  test_acc  \n",
+              "0                   NaN       NaN  \n",
+              "1                   NaN       NaN  \n",
+              "2  [0.2969412701412702]  [0.8949]  "
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-dfcf1d90-bbdb-4501-806b-9663ddff987a\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>model_name</th>\n",
+              "      <th>model_loss</th>\n",
+              "      <th>model_acc</th>\n",
+              "      <th>train_loss</th>\n",
+              "      <th>test_loss</th>\n",
+              "      <th>test_acc</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>FashionMNISTModelV0</td>\n",
+              "      <td>0.499951</td>\n",
+              "      <td>82.268371</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>FashionMNISTModelV1</td>\n",
+              "      <td>0.447740</td>\n",
+              "      <td>83.905751</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Model_2_CNN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>[0.2954221625546614]</td>\n",
+              "      <td>[0.2969412701412702]</td>\n",
+              "      <td>[0.8949]</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-dfcf1d90-bbdb-4501-806b-9663ddff987a')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-dfcf1d90-bbdb-4501-806b-9663ddff987a button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-dfcf1d90-bbdb-4501-806b-9663ddff987a');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "    <div id=\"df-237bd8e0-8f8a-4a3a-a3a7-d0b38d4991d5\">\n",
+              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-237bd8e0-8f8a-4a3a-a3a7-d0b38d4991d5')\"\n",
+              "                title=\"Suggest charts\"\n",
+              "                style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "      </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "      <script>\n",
+              "        async function quickchart(key) {\n",
+              "          const quickchartButtonEl =\n",
+              "            document.querySelector('#' + key + ' button');\n",
+              "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "          try {\n",
+              "            const charts = await google.colab.kernel.invokeFunction(\n",
+              "                'suggestCharts', [key], {});\n",
+              "          } catch (error) {\n",
+              "            console.error('Error during call to suggestCharts:', error);\n",
+              "          }\n",
+              "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "        }\n",
+              "        (() => {\n",
+              "          let quickchartButtonEl =\n",
+              "            document.querySelector('#df-237bd8e0-8f8a-4a3a-a3a7-d0b38d4991d5 button');\n",
+              "          quickchartButtonEl.style.display =\n",
+              "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "        })();\n",
+              "      </script>\n",
+              "    </div>\n",
+              "\n",
+              "  <div id=\"id_f9fffffb-4757-4b39-ae28-c6e54d20e1a8\">\n",
+              "    <style>\n",
+              "      .colab-df-generate {\n",
+              "        background-color: #E8F0FE;\n",
+              "        border: none;\n",
+              "        border-radius: 50%;\n",
+              "        cursor: pointer;\n",
+              "        display: none;\n",
+              "        fill: #1967D2;\n",
+              "        height: 32px;\n",
+              "        padding: 0 0 0 0;\n",
+              "        width: 32px;\n",
+              "      }\n",
+              "\n",
+              "      .colab-df-generate:hover {\n",
+              "        background-color: #E2EBFA;\n",
+              "        box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "        fill: #174EA6;\n",
+              "      }\n",
+              "\n",
+              "      [theme=dark] .colab-df-generate {\n",
+              "        background-color: #3B4455;\n",
+              "        fill: #D2E3FC;\n",
+              "      }\n",
+              "\n",
+              "      [theme=dark] .colab-df-generate:hover {\n",
+              "        background-color: #434B5C;\n",
+              "        box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "        filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "        fill: #FFFFFF;\n",
+              "      }\n",
+              "    </style>\n",
+              "    <button class=\"colab-df-generate\" onclick=\"generateWithVariable('compare_results')\"\n",
+              "            title=\"Generate code using this dataframe.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "       width=\"24px\">\n",
+              "    <path d=\"M7,19H8.4L18.45,9,17,7.55,7,17.6ZM5,21V16.75L18.45,3.32a2,2,0,0,1,2.83,0l1.4,1.43a1.91,1.91,0,0,1,.58,1.4,1.91,1.91,0,0,1-.58,1.4L9.25,21ZM18.45,9,17,7.55Zm-12,3A5.31,5.31,0,0,0,4.9,8.1,5.31,5.31,0,0,0,1,6.5,5.31,5.31,0,0,0,4.9,4.9,5.31,5.31,0,0,0,6.5,1,5.31,5.31,0,0,0,8.1,4.9,5.31,5.31,0,0,0,12,6.5,5.46,5.46,0,0,0,6.5,12Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "    <script>\n",
+              "      (() => {\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#id_f9fffffb-4757-4b39-ae28-c6e54d20e1a8 button.colab-df-generate');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      buttonEl.onclick = () => {\n",
+              "        google.colab.notebook.generateWithVariable('compare_results');\n",
+              "      }\n",
+              "      })();\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "    </div>\n",
+              "  </div>\n"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "dataframe",
+              "variable_name": "compare_results",
+              "summary": "{\n  \"name\": \"compare_results\",\n  \"rows\": 3,\n  \"fields\": [\n    {\n      \"column\": \"model_name\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 3,\n        \"samples\": [\n          \"FashionMNISTModelV0\",\n          \"FashionMNISTModelV1\",\n          \"Model_2_CNN\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"model_loss\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.036918468732844864,\n        \"min\": 0.44774019718170166,\n        \"max\": 0.4999507963657379,\n        \"num_unique_values\": 2,\n        \"samples\": [\n          0.44774019718170166,\n          0.4999507963657379\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"model_acc\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1578026369268488,\n        \"min\": 82.26837060702876,\n        \"max\": 83.90575079872204,\n        \"num_unique_values\": 2,\n        \"samples\": [\n          83.90575079872204,\n          82.26837060702876\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"train_loss\",\n      \"properties\": {\n        \"dtype\": \"object\",\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"test_loss\",\n      \"properties\": {\n        \"dtype\": \"object\",\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"test_acc\",\n      \"properties\": {\n        \"dtype\": \"object\",\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
+            }
+          },
+          "metadata": {},
+          "execution_count": 60
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Visulizing the results"
+      ],
+      "metadata": {
+        "id": "IEUOWM3hrM7r"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Visualize our model results\n",
+        "compare_results.set_index(\"model_name\")[\"model_acc\"].plot(kind=\"barh\")\n",
+        "plt.xlabel(\"accuracy (%)\")\n",
+        "plt.ylabel(\"model\");"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 449
+        },
+        "id": "Bp35h6WErYhU",
+        "outputId": "663c5492-3304-451e-e648-c70a729727f7"
+      },
+      "execution_count": 61,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAr0AAAGwCAYAAACkUt2bAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAO8ZJREFUeJzt3XlcVmX+//H3rewgouISBqIgKgqKmWvauHwHHbImyzFzDW2yNOLrilmjpoamVNqikynYlGkFWpnpmIoTZOWGSzKKu+U6muCKBOf3Rz/vb3egAuIQV6/n43EeeZ9znet8rnMS3hyvc7BZlmUJAAAAMFil8i4AAAAAuN0IvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8p/IuAPgtKCgo0LFjx1SlShXZbLbyLgcAABSDZVk6f/68/Pz8VKnSje/lEnoBSceOHZO/v395lwEAAErh6NGjuvPOO2/YhtALSKpSpYqkn//SeHt7l3M1AACgOHJycuTv72//Pn4jhF5Ask9p8Pb2JvQCAFDBFGdqIg+yAQAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvYZJTU2VzWbTuXPnir1PYGCgXn311dtWEwAAQHkj9P6XDR48WDabTcOGDSu0bfjw4bLZbBo8ePB/v7BiOHv2rJ5++mk1atRI7u7uCggIUExMjLKzs0vUT3Jysv7whz+oatWq8vLyUnh4uF544QWdPXtWkpSUlCSbzabu3bs77Hfu3DnZbDalpqba19lsNrm5uenw4cMObf/85z//Zs8jAAD47yP0lgN/f38tWbJEly9ftq+7cuWKFi9erICAgHKs7MaOHTumY8eOadasWdq1a5eSkpK0atUqDRkypNh9TJgwQX369NHdd9+tzz//XLt27VJCQoK2b9+uf/zjH/Z2Tk5O+uKLL7R+/fqb9mmz2fS3v/2tVGMCAAC/D4TectCyZUv5+/srJSXFvi4lJUUBAQGKiIiwr8vNzVVMTIxq1aolNzc33XPPPdq0aZNDXytXrlRISIjc3d3VuXNnHTp0qNDx0tLS1LFjR7m7u8vf318xMTG6ePFiietu1qyZkpOT1bNnTwUFBalLly6aNm2aPv30U/3000833f/bb7/Viy++qISEBM2cOVPt27dXYGCg/ud//kfJyckaNGiQva2np6eio6MVFxd3035HjBihd999V7t27SrxmAAAwO8DobecREdHKzEx0f554cKFeuyxxxzajB07VsnJyVq0aJG2bt2q4OBgRUZG2qcBHD16VL169VLPnj2VkZGhoUOHFgqJ+/fvV/fu3fXQQw9px44dWrp0qdLS0jRixIgyGUd2dra8vb3l5OR007bvvfeevLy89NRTTxW53cfHx+HzpEmTtHPnTn300Uc37LdDhw667777ihWQr8nNzVVOTo7DAgAAzEXoLSf9+/dXWlqaDh8+rMOHDys9PV39+/e3b7948aLmzp2rmTNnqkePHgoNDdX8+fPl7u6uBQsWSJLmzp2roKAgJSQkqFGjRurXr1+heazx8fHq16+fYmNj1bBhQ7Vv315z5szRO++8oytXrtzSGP7zn/9oypQp+utf/1qs9llZWWrQoIGcnZ2L1d7Pz0/PPPOMJkyYcNM7yfHx8Vq1apW+/PLLYvUdHx+vqlWr2hd/f/9i7QcAAComQm85qVmzpqKiopSUlKTExERFRUXJ19fXvn3//v3Ky8tThw4d7OucnZ3VunVrZWZmSpIyMzPVpk0bh37btWvn8Hn79u1KSkqSl5eXfYmMjFRBQYEOHjxY6vpzcnIUFRWl0NBQTZo0qVj7WJZV4uOMGzdOp0+f1sKFC2/YLjQ0VAMHDiz23d7x48crOzvbvhw9erTEtQEAgIrj5v8mjdsmOjraPs3gjTfeuC3HuHDhgp544gnFxMQU2lbah+bOnz+v7t27q0qVKlq2bFmx79yGhIQoLS1NeXl5xd7Hx8dH48eP1+TJk3XffffdsO3kyZMVEhKi5cuX37RfV1dXubq6FqsGAABQ8XGntxx1795dV69eVV5eniIjIx22BQUFycXFRenp6fZ1eXl52rRpk0JDQyVJTZo00bfffuuw39dff+3wuWXLltq9e7eCg4MLLS4uLiWuOScnR3/84x/l4uKiTz75RG5ubsXe99FHH9WFCxf05ptvFrn9eu8Wfvrpp1WpUiXNnj37hv37+/trxIgRevbZZ5Wfn1/sugAAgPkIveWocuXKyszM1O7du1W5cmWHbZ6ennryySc1ZswYrVq1Srt379bjjz+uS5cu2V8RNmzYMGVlZWnMmDHas2ePFi9erKSkJId+xo0bp6+++kojRoxQRkaGsrKy9PHHH5fqQbZrgffixYtasGCBcnJydOLECZ04caJYIbNNmzYaO3asRo0apbFjx2rjxo06fPiw1q5dq969e2vRokVF7ufm5qbJkydrzpw5Nz3G+PHjdezYMX3xxRclHh8AADAXobeceXt7y9vbu8ht06dP10MPPaQBAwaoZcuW2rdvn1avXq1q1apJ+nl6QnJyspYvX67mzZtr3rx5evHFFx36CA8P14YNG7R371517NhRERER+tvf/iY/P78S17p161Z988032rlzp4KDg3XHHXfYl+LOiZ0xY4YWL16sb775RpGRkWratKlGjhyp8PBwh1eW/dqgQYPUoEGDm/ZfvXp1jRs37pYf0gMAAGaxWaV5uggwTE5OjqpWrWp/BRsAAPjtK8n3b+70AgAAwHiEXthd++URRS1Nmza96f7Dhg277v7Dhg37L4wAAACgaExvgN358+d18uTJIrc5OzurXr16N9z/1KlT1/3NZt7e3qpVq9Yt13i7ML0BAICKpyTfv3lPL+yqVKmiKlWqlHr/WrVq/aaDLQAA+P1iegMAAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIznVN4FAL8lzSauViVXj/IuAwAAoxyaHlXeJXCnFwAAAOYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPKfiNqxWrZpsNlux2p49e7bUBQEAAABlrdih99VXX72NZQAAAAC3T7FD76BBg25nHQAAAMBtU+o5vfv379dzzz2nvn376tSpU5Kkzz//XN99912ZFQcAAACUhVKF3g0bNigsLEzffPONUlJSdOHCBUnS9u3bNXHixDItEAAAALhVpQq9cXFxmjp1qtasWSMXFxf7+i5duujrr78us+IAAACAslCq0Ltz5049+OCDhdbXqlVL//nPf265KAAAAKAslSr0+vj46Pjx44XWb9u2TXXr1r3logAAAICyVKrQ+8gjj2jcuHE6ceKEbDabCgoKlJ6ertGjR2vgwIFlXSMAAABwS0oVel988UU1btxY/v7+unDhgkJDQ9WpUye1b99ezz33XFnXCAAAANySYr+n95dcXFw0f/58Pf/889q1a5cuXLigiIgINWzYsKzrAwAAAG5ZqULvNQEBAQoICCirWgAAAIDbotihd+TIkcXu9OWXXy5VMWUhNTVVnTt31o8//igfH58i20yaNEnLly9XRkbGf7W235viXItfCwwMVGxsrGJjY29rbQAA4Pel2HN6t23b5rAsWLBAf//735WamqrU1FS99dZbWrBgQYmC5ODBg2Wz2Qot+/btK81Yim306NFau3ZtmfaZmpoqm82matWq6cqVKw7bNm3aZB/br9s3bdpU+fn5Du19fHyUlJRk/xwYGKhXX33V/nn79u26//77VatWLbm5uSkwMFB9+vTRqVOnNGnSpCLP6S8X6f/O/bBhwwqNZfjw4bLZbBo8ePCtn5hSunr1qnx9fTV9+vQit0+ZMkW1a9dWXl6ejh8/rkcffVQhISGqVKkSgRkAABRS7NC7fv16+9KzZ0/de++9+v7777V161Zt3bpVR48eVefOnRUVFVWiArp3767jx487LPXr1y/xQErCy8tLNWrUuC19V6lSRcuWLXNYt2DBgutOAzlw4IDeeeedYvd/+vRpde3aVdWrV9fq1auVmZmpxMRE+fn56eLFixo9erTDubzzzjv1wgsvOKy7xt/fX0uWLNHly5ft665cuaLFixeX+7QVFxcX9e/fX4mJiYW2WZalpKQkDRw4UM7OzsrNzVXNmjX13HPPqXnz5uVQLQAA+K0r1dsbEhISFB8fr2rVqtnXVatWTVOnTlVCQkKJ+nJ1dVWdOnUcltmzZyssLEyenp7y9/fXU089Zf9Vx5J0+PBh9ezZU9WqVZOnp6eaNm2qlStXOvS7ZcsWtWrVSh4eHmrfvr327Nlj3zZp0iS1aNHC/rmgoEAvvPCC7rzzTrm6uqpFixZatWqVffuhQ4dks9mUkpKizp07y8PDQ82bN9fGjRsLjWfQoEFauHCh/fPly5e1ZMkSDRo0qMjxP/3005o4caJyc3OLdb7S09OVnZ2tt99+WxEREapfv746d+6sV155RfXr15eXl5fDuaxcubKqVKnisO6ali1byt/fXykpKfZ1KSkpCggIUEREhMNxc3NzFRMTY7+7fM8992jTpk0ObVauXKmQkBC5u7urc+fOOnToUKH609LS1LFjR7m7u8vf318xMTG6ePFikWMdMmSI9u7dq7S0NIf1GzZs0IEDBzRkyBBJP98Jnz17tgYOHKiqVasW6zwCAIDfl1KF3pycHJ0+fbrQ+tOnT+v8+fO3XlSlSpozZ46+++47LVq0SOvWrdPYsWPt24cPH67c3Fz961//0s6dOzVjxgx5eXk59DFhwgQlJCRo8+bNcnJyUnR09HWPN3v2bCUkJGjWrFnasWOHIiMjdf/99ysrK6tQn6NHj1ZGRoZCQkLUt29f/fTTTw5tBgwYoC+//FJHjhyRJCUnJyswMFAtW7Ys8tixsbH66aef9NprrxXr3NSpU0c//fSTli1bJsuyirXPjURHRzvcTV24cKEee+yxQu3Gjh2r5ORkLVq0SFu3blVwcLAiIyN19uxZSdLRo0fVq1cv9ezZUxkZGRo6dKji4uIc+ti/f7+6d++uhx56SDt27NDSpUuVlpamESNGFFlbWFiY7r77bocfIiQpMTFR7du3V+PGjUs97tzcXOXk5DgsAADAXKUKvQ8++KAee+wxpaSk6Pvvv9f333+v5ORkDRkyRL169SpRXytWrJCXl5d96d27t2JjY9W5c2cFBgaqS5cumjp1qj744AP7PkeOHFGHDh0UFhamBg0a6L777lOnTp0c+p02bZruvfdehYaGKi4uTl999VWhubbXzJo1S+PGjdMjjzyiRo0aacaMGWrRooXDPFrp57nAUVFRCgkJ0eTJk3X48OFC849r1aqlHj162OfkLly48IaB28PDQxMnTlR8fLyys7Nver7atm2rZ599Vo8++qh8fX3Vo0cPzZw5UydPnrzpvkXp37+/0tLSdPjwYR0+fFjp6enq37+/Q5uLFy9q7ty5mjlzpnr06KHQ0FDNnz9f7u7uWrBggSRp7ty5CgoKUkJCgho1aqR+/foVmhMcHx+vfv36KTY2Vg0bNlT79u01Z84cvfPOO9e9NkOGDNGHH35ov9N//vx5ffTRRzc8p8URHx+vqlWr2hd/f/9b6g8AAPy2lSr0zps3Tz169NCjjz6qevXqqV69enr00UfVvXt3vfnmmyXqq3PnzsrIyLAvc+bM0RdffKGuXbuqbt26qlKligYMGKAzZ87o0qVLkqSYmBhNnTpVHTp00MSJE7Vjx45C/YaHh9v/fMcdd0iSTp06VahdTk6Ojh07pg4dOjis79ChgzIzM0vVZ3R0tJKSknTgwAFt3LhR/fr1u+E5GDJkiGrUqKEZM2bcsN0106ZN04kTJzRv3jw1bdpU8+bNU+PGjbVz585i7f9LNWvWVFRUlJKSkpSYmKioqCj5+vo6tNm/f7/y8vIczpGzs7Nat25tP0eZmZlq06aNw37t2rVz+Lx9+3YlJSU5/JATGRmpgoICHTx4sMj6+vbtq/z8fPsPPUuXLlWlSpXUp0+fEo/1l8aPH6/s7Gz7cvTo0VvqDwAA/LaVKvR6eHjozTff1JkzZ+xvczh79qzefPNNeXp6lqgvT09PBQcH25fc3Fzdd999Cg8PV3JysrZs2aI33nhD0s9P9EvS0KFDdeDAAQ0YMEA7d+5Uq1atCk0PcHZ2tv/52hsLCgoKSjPcEvfZo0cPXb58WUOGDFHPnj1v+tCck5OTpk2bptmzZ+vYsWPFqqVGjRrq3bu3Zs2apczMTPn5+WnWrFklGM3/uRbSFy1adMt3UG/kwoULeuKJJxx+yNm+fbuysrIUFBRU5D7e3t56+OGH7VMwEhMT9Ze//KXQdJaScnV1lbe3t8MCAADMVarQe42np6eqV6+u6tWrlzjsXs+WLVtUUFCghIQEtW3bViEhIUUGQX9/fw0bNkwpKSkaNWqU5s+fX6rjeXt7y8/PT+np6Q7r09PTFRoaWqo+nZycNHDgQKWmphY7RPbu3VtNmzbV5MmTS3w8FxcXBQUFXfeBsJvp3r27rl69qry8PEVGRhbaHhQUJBcXF4dzlJeXp02bNtnPUZMmTfTtt9867Pf11187fG7ZsqV2797t8EPOtcXFxeW69Q0ZMkRpaWlasWKFvvrqK/sDbAAAAMVVqtB77W0HVatWtU9v8PHx0ZQpU275bmpwcLDy8vL02muv6cCBA/rHP/6hefPmObSJjY3V6tWrdfDgQW3dulXr169XkyZNSn3MMWPGaMaMGVq6dKn27NmjuLg4ZWRk6Jlnnil1n1OmTNHp06eLDJHXM336dC1cuPCG4XXFihXq37+/VqxYob1792rPnj2aNWuWVq5cqQceeKBUtVauXFmZmZnavXu3KleuXGi7p6ennnzySY0ZM0arVq3S7t279fjjj+vSpUv2ADps2DBlZWVpzJgx2rNnjxYvXuzwrmFJGjdunL766iuNGDFCGRkZysrK0scff3zdB9mu6dSpk4KDgzVw4EA1btxY7du3L9Tm2p3jCxcu6PTp08rIyNDu3btLdT4AAIB5SvVriCdMmKAFCxZo+vTp9nmeaWlpmjRpkq5cuaJp06aVuqDmzZvr5Zdf1owZMzR+/Hh16tRJ8fHxGjhwoL1Nfn6+hg8fru+//17e3t7q3r27XnnllVIfMyYmRtnZ2Ro1apROnTql0NBQffLJJ2rYsGGp+3RxcSk0N/ZmunTpoi5duuif//zndduEhobKw8NDo0aN0tGjR+Xq6qqGDRvq7bff1oABA0pd783+eX/69OkqKCjQgAEDdP78ebVq1UqrV6+2v7YuICBAycnJ+t///V+99tprat26tV588UWHO93h4eHasGGDJkyYoI4dO8qyLAUFBd10fq7NZlN0dLSeffZZjR8/vsg2v3zF2pYtW7R48WLVq1evyNemAQCA3x+bVYr3Xvn5+WnevHm6//77HdZ//PHHeuqpp/TDDz+UWYHAf0NOTs7Pb3GI/UCVXD3KuxwAAIxyaHrJfnlZcV37/p2dnX3TG3ilmt5w9uzZIt+R2rhxY/t7WwEAAIDfilKF3ubNm+v1118vtP7111/n18ACAADgN6dUc3pfeuklRUVF6YsvvrC/i3Xjxo06cuSIPv/88zItEAAAALhVpbrTe++992rPnj3q1auXzp07p3PnzqlXr17au3evOnbsWNY1AgAAALekVHd6pZ9/OcL999+vtm3b2l9TtnnzZkkq9IAbAAAAUJ5KFXpXrVqlgQMH6syZM/r1yx9sNpvy8/PLpDgAAACgLJRqesPTTz+t3r1769ixYyooKHBYCLwAAAD4rSlV6D158qRGjhyp2rVrl3U9AAAAQJkrVeh9+OGHlZqaWsalAAAAALdHqeb0vv766+rdu7e+/PJLhYWFydnZ2WF7TExMmRQHAAAAlIVShd73339f//znP+Xm5qbU1FTZbDb7NpvNRugFAADAb0qpQu+ECRM0efJkxcXFqVKlUs2QAAAAAP5rSpVYr169qj59+hB4AQAAUCGUKrUOGjRIS5cuLetaAAAAgNuiVNMb8vPz9dJLL2n16tUKDw8v9CDbyy+/XCbFAQAAAGWhVKF3586dioiIkCTt2rXLYdsvH2oDAAAAfgtKFXrXr19f1nUAAAAAtw1PogEAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwXqne0wuYatfkSHl7e5d3GQAAoIxxpxcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4zmVdwHAb0mziatVydWjvMsAAKDCODQ9qrxLKBbu9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYz7jQm5qaKpvNpnPnzl23zaRJk9SiRYv/Wk2/V8W5Fr8WGBioV1999bbVBAAAfp/KNfQOHjxYNput0LJv377betzRo0dr7dq1ZdrntYBXrVo1XblyxWHbpk2b7GP7dfumTZsqPz/fob2Pj4+SkpLsn38dBLdv3677779ftWrVkpubmwIDA9WnTx+dOnVKkyZNKvKc/nKR/u/cDxs2rNBYhg8fLpvNpsGDB9/6iSmlq1evytfXV9OnTy9y+5QpU1S7dm3l5eVJ+vl8tmzZUq6urgoODnY4fwAAAOV+p7d79+46fvy4w1K/fv3bekwvLy/VqFHjtvRdpUoVLVu2zGHdggULFBAQUGT7AwcO6J133il2/6dPn1bXrl1VvXp1rV69WpmZmUpMTJSfn58uXryo0aNHO5zLO++8Uy+88ILDumv8/f21ZMkSXb582b7uypUrWrx48XXr/W9xcXFR//79lZiYWGibZVlKSkrSwIED5ezsrIMHDyoqKkqdO3dWRkaGYmNjNXToUK1evbocKgcAAL9F5R56XV1dVadOHYdl9uzZCgsLk6enp/z9/fXUU0/pwoUL9n0OHz6snj17qlq1avL09FTTpk21cuVKh363bNmiVq1aycPDQ+3bt9eePXvs2349vaGgoEAvvPCC7rzzTrm6uqpFixZatWqVffuhQ4dks9mUkpKizp07y8PDQ82bN9fGjRsLjWfQoEFauHCh/fPly5e1ZMkSDRo0qMjxP/3005o4caJyc3OLdb7S09OVnZ2tt99+WxEREapfv746d+6sV155RfXr15eXl5fDuaxcubKqVKnisO6ali1byt/fXykpKfZ1KSkpCggIUEREhMNxc3NzFRMTY7+7fM8992jTpk0ObVauXKmQkBC5u7urc+fOOnToUKH609LS1LFjR7m7u8vf318xMTG6ePFikWMdMmSI9u7dq7S0NIf1GzZs0IEDBzRkyBBJ0rx581S/fn0lJCSoSZMmGjFihB5++GG98sor1z2Pubm5ysnJcVgAAIC5yj30FqVSpUqaM2eOvvvuOy1atEjr1q3T2LFj7duHDx+u3Nxc/etf/9LOnTs1Y8YMeXl5OfQxYcIEJSQkaPPmzXJyclJ0dPR1jzd79mwlJCRo1qxZ2rFjhyIjI3X//fcrKyurUJ+jR49WRkaGQkJC1LdvX/30008ObQYMGKAvv/xSR44ckSQlJycrMDBQLVu2LPLYsbGx+umnn/Taa68V69zUqVNHP/30k5YtWybLsoq1z41ER0c73E1duHChHnvssULtxo4dq+TkZC1atEhbt25VcHCwIiMjdfbsWUnS0aNH1atXL/Xs2VMZGRkaOnSo4uLiHPrYv3+/unfvroceekg7duzQ0qVLlZaWphEjRhRZW1hYmO6++26HHyIkKTExUe3bt1fjxo0lSRs3blS3bt0c2kRGRhb5Q8k18fHxqlq1qn3x9/e/wVkCAAAVXbmH3hUrVsjLy8u+9O7dW7GxsercubMCAwPVpUsXTZ06VR988IF9nyNHjqhDhw4KCwtTgwYNdN9996lTp04O/U6bNk333nuvQkNDFRcXp6+++qrQXNtrZs2apXHjxumRRx5Ro0aNNGPGDLVo0aLQA1WjR49WVFSUQkJCNHnyZB0+fLjQ/ONatWqpR48e9jmlCxcuvGHg9vDw0MSJExUfH6/s7Oybnq+2bdvq2Wef1aOPPipfX1/16NFDM2fO1MmTJ2+6b1H69++vtLQ0HT58WIcPH1Z6err69+/v0ObixYuaO3euZs6cqR49eig0NFTz58+Xu7u7FixYIEmaO3eugoKClJCQoEaNGqlfv36F5gTHx8erX79+io2NVcOGDdW+fXvNmTNH77zzznWvzZAhQ/Thhx/a7/SfP39eH330kcM5PXHihGrXru2wX+3atZWTk+MwdeOXxo8fr+zsbPty9OjREp03AABQsZR76L02D/PaMmfOHH3xxRfq2rWr6tatqypVqmjAgAE6c+aMLl26JEmKiYnR1KlT1aFDB02cOFE7duwo1G94eLj9z3fccYck6dSpU4Xa5eTk6NixY+rQoYPD+g4dOigzM7NUfUZHRyspKUkHDhzQxo0b1a9fvxuegyFDhqhGjRqaMWPGDdtdM23aNJ04cULz5s1T06ZNNW/ePDVu3Fg7d+4s1v6/VLNmTUVFRSkpKUmJiYmKioqSr6+vQ5v9+/crLy/P4Rw5OzurdevW9nOUmZmpNm3aOOzXrl07h8/bt29XUlKSww85kZGRKigo0MGDB4usr2/fvsrPz7f/0LN06VJVqlRJffr0KfFYf8nV1VXe3t4OCwAAMFe5h15PT08FBwfbl9zcXN13330KDw9XcnKytmzZojfeeEPSz0/0S9LQoUN14MABDRgwQDt37lSrVq0KTQ9wdna2//naGwsKCgpuqdbi9tmjRw9dvnxZQ4YMUc+ePW/60JyTk5OmTZum2bNn69ixY8WqpUaNGurdu7dmzZqlzMxM+fn5adasWSUYzf+5FtIXLVp0w7vSt+rChQt64oknHH7I2b59u7KyshQUFFTkPt7e3nr44YftUzASExP1l7/8xWE6S506dQrd6T558qS8vb3l7u5+28YDAAAqjnIPvb+2ZcsWFRQUKCEhQW3btlVISEiRQdDf31/Dhg1TSkqKRo0apfnz55fqeN7e3vLz81N6errD+vT0dIWGhpaqTycnJw0cOFCpqanFDpG9e/dW06ZNNXny5BIfz8XFRUFBQdd9IOxmunfvrqtXryovL0+RkZGFtgcFBcnFxcXhHOXl5WnTpk32c9SkSRN9++23Dvt9/fXXDp9btmyp3bt3O/yQc21xcXG5bn1DhgxRWlqaVqxYoa+++sr+ANs17dq1K/QKujVr1hS60wwAAH6/nMq7gF8LDg5WXl6eXnvtNfXs2VPp6emaN2+eQ5vY2Fj16NFDISEh+vHHH7V+/Xo1adKk1MccM2aMJk6cqKCgILVo0UKJiYnKyMjQe++9V+o+p0yZojFjxpTo1WjTp08vMnT+0ooVK7RkyRI98sgjCgkJkWVZ+vTTT7Vy5coiX+9VHJUrV7ZPU6hcuXKh7Z6ennryySc1ZswYVa9eXQEBAXrppZd06dIlewAdNmyYEhISNGbMGA0dOlRbtmwp9K7ccePGqW3bthoxYoSGDh0qT09P7d69W2vWrNHrr79+3fo6deqk4OBgDRw4UI0bN1b79u0dtg8bNkyvv/66xo4dq+joaK1bt04ffPCBPvvss1KdDwAAYJ7f3J3e5s2b6+WXX9aMGTPUrFkzvffee4qPj3dok5+fr+HDh6tJkybq3r27QkJC9Oabb5b6mDExMRo5cqRGjRqlsLAwrVq1Sp988okaNmxY6j5dXFzk6+vr8AspbqZLly7q0qVLoTdC/FJoaKg8PDw0atQotWjRQm3bttUHH3ygt99+WwMGDCh1vTeb1zp9+nQ99NBDGjBggFq2bKl9+/Zp9erVqlatmiQpICBAycnJWr58uZo3b6558+bpxRdfdOgjPDxcGzZs0N69e9WxY0dFRETob3/7m/z8/G5Ym81mU3R0tH788cci75zXr19fn332mdasWaPmzZsrISFBb7/99k1/gAAAAL8fNqss3nsFVHA5OTk/v7os9gNVcvUo73IAAKgwDk2PKrdjX/v+nZ2dfdOH0n9zd3oBAACAskboBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjOZV3AcBvya7JkfL29i7vMgAAQBnjTi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4hF4AAAAYj9ALAAAA4xF6AQAAYDxCLwAAAIxH6AUAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvQAAADAeoRcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwAAAMYj9AIAAMB4TuVdAPBbYFmWJCknJ6ecKwEAAMV17fv2te/jN0LoBSSdOXNGkuTv71/OlQAAgJI6f/68qlatesM2hF5AUvXq1SVJR44cuelfmooqJydH/v7+Onr0qLy9vcu7nDLH+Co+08fI+Co208cnVcwxWpal8+fPy8/P76ZtCb2ApEqVfp7eXrVq1QrzF720vL29jR4j46v4TB8j46vYTB+fVPHGWNybVTzIBgAAAOMRegEAAGA8Qi8gydXVVRMnTpSrq2t5l3LbmD5GxlfxmT5GxlexmT4+yfwx2qzivOMBAAAAqMC40wsAAADjEXoBAABgPEIvAAAAjEfoBQAAgPEIvYCkN954Q4GBgXJzc1ObNm307bfflndJpfKvf/1LPXv2lJ+fn2w2m5YvX+6w3bIs/e1vf9Mdd9whd3d3devWTVlZWeVTbCnEx8fr7rvvVpUqVVSrVi39+c9/1p49exzaXLlyRcOHD1eNGjXk5eWlhx56SCdPniyniktu7ty5Cg8Pt78cvl27dvr888/t2yv6+H5t+vTpstlsio2Nta+ryGOcNGmSbDabw9K4cWP79oo8tmt++OEH9e/fXzVq1JC7u7vCwsK0efNm+/aK/nUmMDCw0DW02WwaPny4pIp/DfPz8/X888+rfv36cnd3V1BQkKZMmaJfvtegol/D67KA37klS5ZYLi4u1sKFC63vvvvOevzxxy0fHx/r5MmT5V1aia1cudKaMGGClZKSYkmyli1b5rB9+vTpVtWqVa3ly5db27dvt+6//36rfv361uXLl8un4BKKjIy0EhMTrV27dlkZGRnWn/70JysgIMC6cOGCvc2wYcMsf39/a+3atdbmzZuttm3bWu3bty/Hqkvmk08+sT777DNr79691p49e6xnn33WcnZ2tnbt2mVZVsUf3y99++23VmBgoBUeHm4988wz9vUVeYwTJ060mjZtah0/fty+nD592r69Io/Nsizr7NmzVr169azBgwdb33zzjXXgwAFr9erV1r59++xtKvrXmVOnTjlcvzVr1liSrPXr11uWVfGv4bRp06waNWpYK1assA4ePGh9+OGHlpeXlzV79mx7m4p+Da+H0IvfvdatW1vDhw+3f87Pz7f8/Pys+Pj4cqzq1v069BYUFFh16tSxZs6caV937tw5y9XV1Xr//ffLocJbd+rUKUuStWHDBsuyfh6Ps7Oz9eGHH9rbZGZmWpKsjRs3lleZt6xatWrW22+/bdT4zp8/bzVs2NBas2aNde+999pDb0Uf48SJE63mzZsXua2ij82yLGvcuHHWPffcc93tJn6deeaZZ6ygoCCroKDAiGsYFRVlRUdHO6zr1auX1a9fP8uyzLyG1zC9Ab9rV69e1ZYtW9StWzf7ukqVKqlbt27auHFjOVZW9g4ePKgTJ044jLVq1apq06ZNhR1rdna2JKl69eqSpC1btigvL89hjI0bN1ZAQECFHGN+fr6WLFmiixcvql27dkaNb/jw4YqKinIYi2TGNczKypKfn58aNGigfv366ciRI5LMGNsnn3yiVq1aqXfv3qpVq5YiIiI0f/58+3bTvs5cvXpV7777rqKjo2Wz2Yy4hu3bt9fatWu1d+9eSdL27duVlpamHj16SDLvGv6SU3kXAJSn//znP8rPz1ft2rUd1teuXVv//ve/y6mq2+PEiROSVORYr22rSAoKChQbG6sOHTqoWbNmkn4eo4uLi3x8fBzaVrQx7ty5U+3atdOVK1fk5eWlZcuWKTQ0VBkZGUaMb8mSJdq6das2bdpUaFtFv4Zt2rRRUlKSGjVqpOPHj2vy5Mnq2LGjdu3aVeHHJkkHDhzQ3LlzNXLkSD377LPatGmTYmJi5OLiokGDBhn3dWb58uU6d+6cBg8eLKni//8pSXFxccrJyVHjxo1VuXJl5efna9q0aerXr58k875X/BKhF0CFNHz4cO3atUtpaWnlXUqZa9SokTIyMpSdna2PPvpIgwYN0oYNG8q7rDJx9OhRPfPMM1qzZo3c3NzKu5wyd+1umSSFh4erTZs2qlevnj744AO5u7uXY2Vlo6CgQK1atdKLL74oSYqIiNCuXbs0b948DRo0qJyrK3sLFixQjx495OfnV96llJkPPvhA7733nhYvXqymTZsqIyNDsbGx8vPzM/Ia/hLTG/C75uvrq8qVKxd68vbkyZOqU6dOOVV1e1wbjwljHTFihFasWKH169frzjvvtK+vU6eOrl69qnPnzjm0r2hjdHFxUXBwsO666y7Fx8erefPmmj17thHj27Jli06dOqWWLVvKyclJTk5O2rBhg+bMmSMnJyfVrl27wo/xl3x8fBQSEqJ9+/YZcf3uuOMOhYaGOqxr0qSJfQqHSV9nDh8+rC+++EJDhw61rzPhGo4ZM0ZxcXF65JFHFBYWpgEDBuh///d/FR8fL8msa/hrhF78rrm4uOiuu+7S2rVr7esKCgq0du1atWvXrhwrK3v169dXnTp1HMaak5Ojb775psKM1bIsjRgxQsuWLdO6detUv359h+133XWXnJ2dHca4Z88eHTlypMKMsSgFBQXKzc01Ynxdu3bVzp07lZGRYV9atWqlfv362f9c0cf4SxcuXND+/ft1xx13GHH9OnToUOg1gXv37lW9evUkmfF15prExETVqlVLUVFR9nUmXMNLly6pUiXH+Fe5cmUVFBRIMusaFlLeT9IB5W3JkiWWq6urlZSUZO3evdv661//avn4+FgnTpwo79JK7Pz589a2bdusbdu2WZKsl19+2dq2bZt1+PBhy7J+fg2Nj4+P9fHHH1s7duywHnjggQr1Gponn3zSqlq1qpWamurwSqFLly7Z2wwbNswKCAiw1q1bZ23evNlq166d1a5du3KsumTi4uKsDRs2WAcPHrR27NhhxcXFWTabzfrnP/9pWVbFH19Rfvn2Bsuq2GMcNWqUlZqaah08eNBKT0+3unXrZvn6+lqnTp2yLKtij82yfn7NnJOTkzVt2jQrKyvLeu+99ywPDw/r3Xfftbep6F9nLOvnt/gEBARY48aNK7Stol/DQYMGWXXr1rW/siwlJcXy9fW1xo4da29jwjUsCqEXsCzrtddeswICAiwXFxerdevW1tdff13eJZXK+vXrLUmFlkGDBlmW9fOraJ5//nmrdu3alqurq9W1a1drz5495Vt0CRQ1NklWYmKivc3ly5etp556yqpWrZrl4eFhPfjgg9bx48fLr+gSio6OturVq2e5uLhYNWvWtLp27WoPvJZV8cdXlF+H3oo8xj59+lh33HGH5eLiYtWtW9fq06ePwztsK/LYrvn000+tZs2aWa6urlbjxo2tt956y2F7Rf86Y1mWtXr1aktSkXVX9GuYk5NjPfPMM1ZAQIDl5uZmNWjQwJowYYKVm5trb2PCNSyKzbJ+8Ss4AAAAAAMxpxcAAADGI/QCAADAeIReAAAAGI/QCwAAAOMRegEAAGA8Qi8AAACMR+gFAACA8Qi9AAAAMB6hFwCAMtCpUyctXrz4lvpo27atkpOTy6giAL9E6AUA4BZ98sknOnnypB555BH7upEjR6p69ery9/fXe++959D+ww8/VM+ePQv189xzzykuLk4FBQW3vWbg94ZfQwwAMEJeXp6cnZ3L5djdunVTt27dFBcXJ0n69NNP9fjjj2vFihXKyspSdHS0jh49Kl9fX2VnZ+vuu+/WF198oYCAAId+8vPzVbduXS1YsEBRUVHlMRTAWNzpBQCU2KpVq3TPPffIx8dHNWrU0H333af9+/c7tPn+++/Vt29fVa9eXZ6enmrVqpW++eYb+/ZPP/1Ud999t9zc3OTr66sHH3zQvs1ms2n58uUO/fn4+CgpKUmSdOjQIdlsNi1dulT33nuv3Nzc9N577+nMmTPq27ev6tatKw8PD4WFhen999936KegoEAvvfSSgoOD5erqqoCAAE2bNk2S1KVLF40YMcKh/enTp+Xi4qK1a9cWeS5Onz6tdevWOdy5zczM1B/+8Ae1atVKffv2lbe3tw4ePChJGjt2rJ588slCgVeSKleurD/96U9asmRJkccCUHqEXgBAiV28eFEjR47U5s2btXbtWlWqVEkPPvig/Z/lL1y4oHvvvVc//PCDPvnkE23fvl1jx461b//ss8/04IMP6k9/+pO2bdumtWvXqnXr1iWuIy4uTs8884wyMzMVGRmpK1eu6K677tJnn32mXbt26a9//asGDBigb7/91r7P+PHjNX36dD3//PPavXu3Fi9erNq1a0uShg4dqsWLFys3N9fe/t1331XdunXVpUuXImtIS0uTh4eHmjRpYl/XvHlzbd68WT/++KO2bNmiy5cvKzg4WGlpadq6datiYmKuO6bWrVvryy+/LPG5AHATFgAAt+j06dOWJGvnzp2WZVnW3//+d6tKlSrWmTNnimzfrl07q1+/ftftT5K1bNkyh3VVq1a1EhMTLcuyrIMHD1qSrFdfffWmtUVFRVmjRo2yLMuycnJyLFdXV2v+/PlFtr18+bJVrVo1a+nSpfZ14eHh1qRJk67b/yuvvGI1aNCg0PqJEydaQUFBVrNmzayUlBQrNzfXatasmbV582brtddes0JCQqz27dtbu3btctjv448/tipVqmTl5+ffdGwAio87vQCAEsvKylLfvn3VoEEDeXt7KzAwUJJ05MgRSVJGRoYiIiJUvXr1IvfPyMhQ165db7mOVq1aOXzOz8/XlClTFBYWpurVq8vLy0urV6+215WZmanc3NzrHtvNzU0DBgzQwoULJUlbt27Vrl27NHjw4OvWcPnyZbm5uRVaP2nSJO3bt087d+7Ugw8+qPj4eHXr1k3Ozs6aOnWq0tLSNHToUA0cONBhP3d3dxUUFDjcbQZw65zKuwAAQMXTs2dP1atXT/Pnz5efn58KCgrUrFkzXb16VdLPwe1GbrbdZrPJ+tVz1nl5eYXaeXp6OnyeOXOmZs+erVdffVVhYWHy9PRUbGxsseuSfp7i0KJFC33//fdKTExUly5dVK9eveu29/X11Y8//njDPv/973/r3Xff1bZt27Rw4UJ16tRJNWvW1F/+8hdFR0fr/PnzqlKliiTp7Nmz8vT0LFatAIqPO70AgBI5c+aM9uzZo+eee05du3ZVkyZNCoW+8PBwZWRk6OzZs0X2ER4eft0HwySpZs2aOn78uP1zVlaWLl26dNPa0tPT9cADD6h///5q3ry5GjRooL1799q3N2zYUO7u7jc8dlhYmFq1aqX58+dr8eLFio6OvuExIyIidOLEiesGX8uy9MQTT+jll1+Wl5eX8vPz7QH+2n/z8/Pt7Xft2qWIiIibjhVAyRB6AQAlUq1aNdWoUUNvvfWW9u3bp3Xr1mnkyJEObfr27as6deroz3/+s9LT03XgwAElJydr48aNkqSJEyfq/fff18SJE5WZmamdO3dqxowZ9v27dOmi119/Xdu2bdPmzZs1bNiwYr2OrGHDhlqzZo2++uorZWZm6oknntDJkyft293c3DRu3DiNHTtW77zzjvbv36+vv/5aCxYscOhn6NChmj59uizLcnirRFEiIiLk6+ur9PT0Ire//fbbqlmzpv3tDh06dNC6dev09ddf65VXXlFoaKh8fHzs7b/88kv98Y9/vOlYAZRQOc8pBgBUQGvWrLGaNGliubq6WuHh4VZqamqhh88OHTpkPfTQQ5a3t7fl4eFhtWrVyvrmm2/s25OTk60WLVpYLi4ulq+vr9WrVy/7th9++MH64x//aHl6eloNGza0Vq5cWeSDbNu2bXOo68yZM9YDDzxgeXl5WbVq1bKee+45a+DAgdYDDzxgb5Ofn29NnTrVqlevnuXs7GwFBARYL774okM/58+ftzw8PKynnnqqWOdj7Nix1iOPPFJo/YkTJ6x69epZP/zwg8P6yZMnW9WrV7caN27scE6+//57y9nZ2Tp69Gixjgug+PjlFAAA/MqhQ4cUFBSkTZs2qWXLljdtf+LECTVt2lRbt2694fzfmxk3bpx+/PFHvfXWW6XuA0DRmN4AAMD/l5eXpxMnTui5555T27ZtixV4JalOnTpasGCB/S0RpVWrVi1NmTLllvoAUDTu9AIA8P+lpqaqc+fOCgkJ0UcffaSwsLDyLglAGSH0AgAAwHhMbwAAAIDxCL0AAAAwHqEXAAAAxiP0AgAAwHiEXgAAABiP0AsAAADjEXoBAABgPEIvAAAAjPf/AL8TWTCJtSxhAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [],
+      "metadata": {
+        "id": "HZU6ySjWqvF4"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new notebook that loads/explores FashionMNIST, builds DataLoaders, implements baseline/MLP/CNN models, trains/evaluates them, and visualizes results.

Notebook (ch_17_omputer_vision_.ipynb)
Load and explore FashionMNIST; preview samples and class names.
Create DataLoaders and basic data viz utilities.
Models
FashionMNISTModelV0: baseline linear classifier.
FashionMNISTModelV1: 2-layer MLP with ReLU.
FashionMNISTModelV2: TinyVGG-like CNN (Conv/ReLU/Pool blocks + classifier).
Training & Evaluation
Add reusable train_step/test_step and epoch helpers; device-agnostic setup.
Compute metrics (loss/accuracy) with helper accuracy_fn and comparison table.
Results & Visualization
Plot predictions and compare model accuracies; CNN achieves best test accuracy.

issuse closed : 
Fixes #58 
Fixes #59 
Fixes #60 
Fixes #61  
Fixes #62 
Fixes #63 
Fixes #64 
Fixes #65 
Fixes #66 
Fixes #67 
Fixes #68 
Fixes #69 
Fixes #70 
Fixes #71 
Fixes #72 
Fixes #73 